### PR TITLE
[PLUB-107] 모임 생성시 모집 자동 생성 구현

### DIFF
--- a/src/main/java/plub/plubserver/config/security/SecurityConfig.java
+++ b/src/main/java/plub/plubserver/config/security/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .formLogin().disable()
                 .httpBasic().disable() // bearer 방식을 쓸 거다
                 .authorizeRequests()
-                .antMatchers("/api/category/**", "/api/auth/**", "/api/account/check/nickname/**", "/api/test/**").permitAll()
+                .antMatchers("/api/category/**", "/api/auth/**", "/api/account/check/nickname/**", "/api/test/**", "/api/plubbing/**").permitAll()
                 .antMatchers("/docs/**", "/favicon.ico", "/v2/api-docs","/configuration/ui","/swagger-resources/**",
                         "/configuration/security","/swagger-ui.html","/swagger-ui/#", "/webjars/**","/swagger/**", "/swagger-ui/**", "/", "/csrf", "/error").permitAll()
                 .anyRequest()

--- a/src/main/java/plub/plubserver/domain/category/dto/CategoryDto.java
+++ b/src/main/java/plub/plubserver/domain/category/dto/CategoryDto.java
@@ -7,7 +7,7 @@ import plub.plubserver.domain.category.model.SubCategory;
 
 public class CategoryDto {
     public record CategoryListResponse(
-            @ApiModelProperty(value = "카테고리 id", example = "1")
+            @ApiModelProperty(value = "카테고리 plubbingId", example = "1")
             Long id,
             @ApiModelProperty(value = "이름", example = "예술")
             String name,
@@ -31,7 +31,7 @@ public class CategoryDto {
         }
     }
     public record SubCategoryListResponse(
-            @ApiModelProperty(value = "서브 카테고리 id", example = "1")
+            @ApiModelProperty(value = "서브 카테고리 plubbingId", example = "1")
             Long id,
             @ApiModelProperty(value = "순서", example = "1")
             int sequence,

--- a/src/main/java/plub/plubserver/domain/category/dto/CategoryDto.java
+++ b/src/main/java/plub/plubserver/domain/category/dto/CategoryDto.java
@@ -7,7 +7,7 @@ import plub.plubserver.domain.category.model.SubCategory;
 
 public class CategoryDto {
     public record CategoryListResponse(
-            @ApiModelProperty(value = "카테고리 plubbingId", example = "1")
+            @ApiModelProperty(value = "카테고리 id", example = "1")
             Long id,
             @ApiModelProperty(value = "이름", example = "예술")
             String name,
@@ -31,7 +31,7 @@ public class CategoryDto {
         }
     }
     public record SubCategoryListResponse(
-            @ApiModelProperty(value = "서브 카테고리 plubbingId", example = "1")
+            @ApiModelProperty(value = "서브 카테고리 id", example = "1")
             Long id,
             @ApiModelProperty(value = "순서", example = "1")
             int sequence,

--- a/src/main/java/plub/plubserver/domain/plubbing/controller/PlubbingController.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/controller/PlubbingController.java
@@ -21,10 +21,9 @@ public class PlubbingController {
     @PostMapping
     public ApiResponse<PlubbingResponse> createPlubbing(
             @ModelAttribute CreatePlubbingRequest createPlubbingRequest) {
-        log.info("{}", createPlubbingRequest);
         return ApiResponse.success(
-                1,
-                plubbingService.createPlubbing(createPlubbingRequest)
+                plubbingService.createPlubbing(createPlubbingRequest),
+                "plubbing is successfully created."
         );
     }
 }

--- a/src/main/java/plub/plubserver/domain/plubbing/dto/PlubbingDto.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/dto/PlubbingDto.java
@@ -58,7 +58,7 @@ public class PlubbingDto {
             int maxAccountNum,
 
             @Size(max = 5)
-            List<Long> questionIds
+            List<String> questionTitles
     ){
         public PlubbingOnOff getOnOff() {
             if (this.onOff.equals("ON")) return PlubbingOnOff.ON;
@@ -66,20 +66,12 @@ public class PlubbingDto {
         }
     }
 
-    @Builder
-    public record QuestionDto(
-
-            @NotBlank
-            @Size(max = 100)
-            String question
-    ){}
-
     /**
      * Response
      */
     @Builder
     public record PlubbingResponse(
-            Long id,
+            Long plubbingId,
             List<String> subCategories,
             String name,
             String goal,
@@ -90,13 +82,14 @@ public class PlubbingDto {
             Double placePositionY,
             int curAccountNum,
             int maxAccountNum,
-            RecruitResponse recruitResponse,
+            RecruitResponse recruit,
             String createdAt,
             String modifiedAt
     ) {
+        @Builder public PlubbingResponse {}
         public static PlubbingResponse of(Plubbing plubbing) {
             return PlubbingResponse.builder()
-                    .id(plubbing.getId())
+                    .plubbingId(plubbing.getId())
                     .subCategories(plubbing.getPlubbingSubCategories().stream()
                             .map(it -> it.getSubCategory().getName())
                             .toList())
@@ -111,7 +104,7 @@ public class PlubbingDto {
                     .maxAccountNum(plubbing.getMaxAccountNum())
                     .createdAt(plubbing.getCreatedAt())
                     .modifiedAt(plubbing.getModifiedAt())
-//                    .recruitResponse(plubbing.getRecruit()) TODO
+                    .recruit(RecruitResponse.of(plubbing.getRecruit()))
                     .build();
         }
     }

--- a/src/main/java/plub/plubserver/domain/plubbing/dto/PlubbingDto.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/dto/PlubbingDto.java
@@ -50,7 +50,8 @@ public class PlubbingDto {
             @Pattern(regexp = "^(ON|OFF)$", message = "only permit ON or OFF.")
             String onOff,
 
-            // 오프라인시 - 장소 좌표 (온라인이면 0, 0)
+            // 오프라인시 - 장소 좌표 (온라인이면 0.0, 0.0)
+            String address,
             Double placePositionX,
             Double placePositionY,
 
@@ -78,6 +79,7 @@ public class PlubbingDto {
             String mainImageFileName,
             String days,
             String onOff,
+            String address,
             Double placePositionX,
             Double placePositionY,
             int curAccountNum,
@@ -98,6 +100,7 @@ public class PlubbingDto {
                     .mainImageFileName(plubbing.getMainImageFileName())
                     .days(plubbing.getDays())
                     .onOff(plubbing.getOnOff().name())
+                    .address(plubbing.getPlubbingPlace().getAddress())
                     .placePositionX(plubbing.getPlubbingPlace().getPlacePositionX())
                     .placePositionY(plubbing.getPlubbingPlace().getPlacePositionY())
                     .curAccountNum(plubbing.getCurAccountNum())

--- a/src/main/java/plub/plubserver/domain/plubbing/dto/PlubbingDto.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/dto/PlubbingDto.java
@@ -3,7 +3,9 @@ package plub.plubserver.domain.plubbing.dto;
 import lombok.Builder;
 import org.springframework.lang.Nullable;
 import org.springframework.web.multipart.MultipartFile;
+import plub.plubserver.domain.plubbing.model.MeetingDay;
 import plub.plubserver.domain.plubbing.model.Plubbing;
+import plub.plubserver.domain.plubbing.model.PlubbingMeetingDay;
 import plub.plubserver.domain.plubbing.model.PlubbingOnOff;
 import plub.plubserver.domain.recruit.dto.RecruitDto.RecruitResponse;
 
@@ -44,7 +46,7 @@ public class PlubbingDto {
             MultipartFile mainImageFile,
 
             @NotBlank
-            String days, // "월 화 수"
+            List<String> days, // MON, TUE, WED, THR, FRI, SAT, SUN, ALL
 
             @NotBlank
             @Pattern(regexp = "^(ON|OFF)$", message = "only permit ON or OFF.")
@@ -65,6 +67,10 @@ public class PlubbingDto {
             if (this.onOff.equals("ON")) return PlubbingOnOff.ON;
             else return PlubbingOnOff.OFF;
         }
+
+        public List<PlubbingMeetingDay> getPlubbingMeetingDay(Plubbing plubbing) {
+            return this.days.stream().map(it -> new PlubbingMeetingDay(it, plubbing)).toList();
+        }
     }
 
     /**
@@ -77,7 +83,7 @@ public class PlubbingDto {
             String name,
             String goal,
             String mainImageFileName,
-            String days,
+            List<MeetingDay> days,
             String onOff,
             String address,
             Double placePositionX,
@@ -98,7 +104,9 @@ public class PlubbingDto {
                     .name(plubbing.getName())
                     .goal(plubbing.getGoal())
                     .mainImageFileName(plubbing.getMainImageFileName())
-                    .days(plubbing.getDays())
+                    .days(plubbing.getDays().stream()
+                            .map(PlubbingMeetingDay::getDay)
+                            .toList())
                     .onOff(plubbing.getOnOff().name())
                     .address(plubbing.getPlubbingPlace().getAddress())
                     .placePositionX(plubbing.getPlubbingPlace().getPlacePositionX())

--- a/src/main/java/plub/plubserver/domain/plubbing/model/MeetingDay.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/model/MeetingDay.java
@@ -1,0 +1,5 @@
+package plub.plubserver.domain.plubbing.model;
+
+public enum MeetingDay {
+    MON, TUE, WED, THR, FRI, SAT, SUN, ALL
+}

--- a/src/main/java/plub/plubserver/domain/plubbing/model/Plubbing.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/model/Plubbing.java
@@ -1,9 +1,6 @@
 package plub.plubserver.domain.plubbing.model;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import plub.plubserver.common.model.BaseTimeEntity;
 import plub.plubserver.domain.account.model.AccountPlubbing;
 import plub.plubserver.domain.category.model.PlubbingSubCategory;
@@ -16,6 +13,8 @@ import java.util.List;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Plubbing extends BaseTimeEntity {
 
@@ -31,7 +30,9 @@ public class Plubbing extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private PlubbingStatus status; // ACTIVE, END
 
-    private String days; // 월 화 수 목 금 토 일 무
+    @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PlubbingMeetingDay> days = new ArrayList<>();
+//    private String days; // 월 화 수 목 금 토 일 무
 
     @Enumerated(EnumType.STRING)
     private PlubbingOnOff onOff; // ON, OFF
@@ -66,32 +67,20 @@ public class Plubbing extends BaseTimeEntity {
     @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlubbingTimeline> timeLineList = new ArrayList<>();
 
-    @Builder
-    public Plubbing(String name, String goal, String mainImageFileName, PlubbingStatus status, String days, PlubbingOnOff onOff, PlubbingPlace plubbingPlace, int maxAccountNum, int curAccountNum, Recruit recruit, List<PlubbingDate> plubbingDateList, List<AccountPlubbing> accountPlubbingList, List<PlubbingNotice> notices, List<PlubbingSubCategory> plubbingSubCategories, List<PlubbingTimeline> timeLineList) {
-        this.name = name;
-        this.goal = goal;
-        this.mainImageFileName = mainImageFileName;
-        this.status = status;
-        this.days = days;
-        this.onOff = onOff;
-        this.plubbingPlace = plubbingPlace;
-        this.maxAccountNum = maxAccountNum;
-        this.curAccountNum = curAccountNum;
-        this.recruit = recruit;
-        this.plubbingDateList = plubbingDateList;
-        this.accountPlubbingList = accountPlubbingList;
-        this.notices = notices;
-        this.plubbingSubCategories = plubbingSubCategories;
-        this.timeLineList = timeLineList;
-    }
-
-
     /**
      * methods
      */
     // 모임 생성때 서브 카테고리들을 저장함
     public void addPlubbingSubCategories(List<PlubbingSubCategory> plubbingSubCategories) {
         this.plubbingSubCategories.addAll(plubbingSubCategories);
+    }
+
+    public void addPlubbingMeetingDay(List<PlubbingMeetingDay> days) {
+        if (this.days == null) {
+            this.days = new ArrayList<>(days);
+        } else {
+            this.days.addAll(days);
+        }
     }
 
     public void addAccountPlubbing(AccountPlubbing accountPlubbing) {

--- a/src/main/java/plub/plubserver/domain/plubbing/model/Plubbing.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/model/Plubbing.java
@@ -42,20 +42,20 @@ public class Plubbing extends BaseTimeEntity {
     private int curAccountNum; // 현재 인원수
 
     // 모임(1) - 모집(1) # 모임이 부모 : 외래키 관리
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "recruit_id")
     private Recruit recruit;
 
     // 모임(1) - 플러빙 일정(다)
-    @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlubbingDate> plubbingDateList = new ArrayList<>();
 
     // 모임(1) - 회원_모임페이지(다) # 다대다 용
-    @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<AccountPlubbing> accountPlubbingList = new ArrayList<>();
 
     // 모임(1) - 플러빙 공지(다)
-    @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<PlubbingNotice> notices = new ArrayList<>();
 
     // 모임(1) - 모임 카테고리(다)
@@ -100,5 +100,9 @@ public class Plubbing extends BaseTimeEntity {
 
     public void addPlubbingPlace(PlubbingPlace plubbingPlace) {
         this.plubbingPlace = plubbingPlace;
+    }
+
+    public void addRecruit(Recruit recruit) {
+        this.recruit = recruit;
     }
 }

--- a/src/main/java/plub/plubserver/domain/plubbing/model/Plubbing.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/model/Plubbing.java
@@ -31,8 +31,7 @@ public class Plubbing extends BaseTimeEntity {
     private PlubbingStatus status; // ACTIVE, END
 
     @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PlubbingMeetingDay> days = new ArrayList<>();
-//    private String days; // 월 화 수 목 금 토 일 무
+    private List<PlubbingMeetingDay> days;
 
     @Enumerated(EnumType.STRING)
     private PlubbingOnOff onOff; // ON, OFF
@@ -49,30 +48,34 @@ public class Plubbing extends BaseTimeEntity {
 
     // 모임(1) - 플러빙 일정(다)
     @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PlubbingDate> plubbingDateList = new ArrayList<>();
+    private List<PlubbingDate> plubbingDateList;
 
     // 모임(1) - 회원_모임페이지(다) # 다대다 용
     @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<AccountPlubbing> accountPlubbingList = new ArrayList<>();
+    private List<AccountPlubbing> accountPlubbingList;
 
     // 모임(1) - 플러빙 공지(다)
     @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PlubbingNotice> notices = new ArrayList<>();
+    private List<PlubbingNotice> notices;
 
     // 모임(1) - 모임 카테고리(다)
     @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PlubbingSubCategory> plubbingSubCategories = new ArrayList<>();
+    private List<PlubbingSubCategory> plubbingSubCategories;
 
     // 모임(1) - 타임라인(다)
     @OneToMany(mappedBy = "plubbing", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<PlubbingTimeline> timeLineList = new ArrayList<>();
+    private List<PlubbingTimeline> timeLineList;
 
     /**
      * methods
      */
     // 모임 생성때 서브 카테고리들을 저장함
     public void addPlubbingSubCategories(List<PlubbingSubCategory> plubbingSubCategories) {
-        this.plubbingSubCategories.addAll(plubbingSubCategories);
+        if (this.plubbingSubCategories == null) {
+            this.plubbingSubCategories = new ArrayList<>(plubbingSubCategories);
+        } else {
+            this.plubbingSubCategories.addAll(plubbingSubCategories);
+        }
     }
 
     public void addPlubbingMeetingDay(List<PlubbingMeetingDay> days) {
@@ -84,6 +87,7 @@ public class Plubbing extends BaseTimeEntity {
     }
 
     public void addAccountPlubbing(AccountPlubbing accountPlubbing) {
+        if (this.accountPlubbingList == null) this.accountPlubbingList = new ArrayList<>();
         this.accountPlubbingList.add(accountPlubbing);
     }
 

--- a/src/main/java/plub/plubserver/domain/plubbing/model/PlubbingMeetingDay.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/model/PlubbingMeetingDay.java
@@ -9,7 +9,8 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlubbingMeetingDay {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "plubbing_meeting_day_id")
     private Long id;
 
@@ -20,7 +21,7 @@ public class PlubbingMeetingDay {
     private MeetingDay day;
 
     public PlubbingMeetingDay(String day, Plubbing plubbing) {
-        this.day = switch(day) {
+        this.day = switch (day) {
             case "MON" -> MeetingDay.MON;
             case "TUE" -> MeetingDay.TUE;
             case "WED" -> MeetingDay.WED;

--- a/src/main/java/plub/plubserver/domain/plubbing/model/PlubbingMeetingDay.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/model/PlubbingMeetingDay.java
@@ -1,0 +1,39 @@
+package plub.plubserver.domain.plubbing.model;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlubbingMeetingDay {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plubbing_meeting_day_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plubbing_id")
+    private Plubbing plubbing;
+
+    private MeetingDay day;
+
+    public PlubbingMeetingDay(String day, Plubbing plubbing) {
+        this.day = switch(day) {
+            case "MON" -> MeetingDay.MON;
+            case "TUE" -> MeetingDay.TUE;
+            case "WED" -> MeetingDay.WED;
+            case "THR" -> MeetingDay.THR;
+            case "FRI" -> MeetingDay.FRI;
+            case "SAT" -> MeetingDay.SAT;
+            case "SUN" -> MeetingDay.SUN;
+            default -> MeetingDay.ALL;
+        };
+        this.plubbing = plubbing;
+    }
+
+    public void mapPlubbing(Plubbing plubbing) {
+        this.plubbing = plubbing;
+    }
+}

--- a/src/main/java/plub/plubserver/domain/plubbing/model/PlubbingPlace.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/model/PlubbingPlace.java
@@ -7,9 +7,15 @@ import javax.persistence.Embeddable;
 @Embeddable
 @AllArgsConstructor
 @Builder
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 public class PlubbingPlace {
+    private String address;
     private Double placePositionX;
     private Double placePositionY;
+
+    public PlubbingPlace() {
+        this.address = "";
+        this.placePositionX = 0.0;
+        this.placePositionY = 0.0;
+    }
 }

--- a/src/main/java/plub/plubserver/domain/plubbing/service/PlubbingService.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/service/PlubbingService.java
@@ -1,6 +1,7 @@
 package plub.plubserver.domain.plubbing.service;
 
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plub.plubserver.domain.account.model.Account;
@@ -22,7 +23,6 @@ import plub.plubserver.domain.recruit.model.Recruit;
 import plub.plubserver.util.s3.AwsS3Uploader;
 import plub.plubserver.util.s3.S3SaveDir;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -35,32 +35,8 @@ public class PlubbingService {
     private final AccountService accountService;
     private final AccountRepository accountRepository; // for test
 
-    private void mappingCategoriesToPlubbing(CreatePlubbingRequest createPlubbingRequest, Plubbing plubbing) {
-        // 서브 카테고리 가져오기
-        List<SubCategory> subCategories = createPlubbingRequest.subCategories()
-                .stream()
-                .map(categoryService::getSubCategory)
-                .toList();
-
-        // 서브 카테고리 - 모임 매핑 (plubbingSubCategory 엔티티 생성)
-        List<PlubbingSubCategory> plubbingSubCategories = subCategories.stream()
-                .map(subCategory -> PlubbingSubCategory.builder()
-                        .subCategory(subCategory)
-                        .plubbing(plubbing)
-                        .build())
-                .toList();
-        
-        // 플러빙 객체에 추가 - 더티체킹으로 자동 엔티티 저장
-        plubbing.addPlubbingSubCategories(plubbingSubCategories);
-    }
-
-
-    @Transactional
-    public PlubbingResponse createPlubbing(CreatePlubbingRequest createPlubbingRequest) {
-        // 모임 생성자(호스트) 가져오기
-//        Account owner = accountService.getCurrentAccount();
-        Account owner = accountRepository.save(Account.builder().email("test@test.com").build()); // for test
-
+    @Nullable
+    private String uploadMainImage(CreatePlubbingRequest createPlubbingRequest, Account owner) {
         // 메인 이미지 업로드 (선택 했을 시)
         String mainImgFileName = null;
         if (createPlubbingRequest.mainImageFile() != null) {
@@ -69,50 +45,10 @@ public class PlubbingService {
             );
             mainImgFileName = s3FileDto.fileName();
         }
+        return mainImgFileName;
+    }
 
-        // Plubbing 엔티티 생성 및 저장
-        Plubbing plubbing = plubbingRepository.save(
-                Plubbing.builder()
-                        .name(createPlubbingRequest.name())
-                        .goal(createPlubbingRequest.goal())
-                        .mainImageFileName(mainImgFileName)
-                        .status(PlubbingStatus.ACTIVE)
-                        .onOff(createPlubbingRequest.getOnOff())
-                        .maxAccountNum(createPlubbingRequest.maxAccountNum())
-                        .plubbingDateList(new ArrayList<>())
-                        .plubbingSubCategories(new ArrayList<>())
-                        .accountPlubbingList(new ArrayList<>())
-                        .timeLineList(new ArrayList<>())
-                        .build()
-        );
-
-        plubbingRepository.flush();
-        // days 매핑
-        plubbing.addPlubbingMeetingDay(createPlubbingRequest.getPlubbingMeetingDay(plubbing));
-        
-        // 오프라인이면 장소도 저장 (온라인 이면 기본값 저장)
-        switch (plubbing.getOnOff().name()) {
-            case "OFF" -> plubbing.addPlubbingPlace(PlubbingPlace.builder()
-                        .address(createPlubbingRequest.address())
-                        .placePositionX(createPlubbingRequest.placePositionX())
-                        .placePositionY(createPlubbingRequest.placePositionY())
-                        .build());
-
-            case "ON" -> plubbing.addPlubbingPlace(new PlubbingPlace());
-        }
-
-        // Plubbing - PlubbingSubCategory 매핑
-        mappingCategoriesToPlubbing(createPlubbingRequest, plubbing);
-
-        // Plubbing - AccountPlubbing 매핑
-        plubbing.addAccountPlubbing(AccountPlubbing.builder()
-                .isHost(true)
-                .account(owner)
-                .plubbing(plubbing)
-                .accountPlubbingStatus(AccountPlubbingStatus.ACTIVE)
-                .build()
-        );
-
+    private void createRecruit(CreatePlubbingRequest createPlubbingRequest, Plubbing plubbing) {
         // 모집 질문글 엔티티화
         List<Question> questionList = createPlubbingRequest.questionTitles().stream()
                 .map(it -> Question.builder()
@@ -127,15 +63,85 @@ public class PlubbingService {
                 .plubbing(plubbing)
                 .questions(questionList)
                 .build();
-        
+
         // 질문 - 모집 매핑
         questionList.forEach(it -> it.addRecruit(recruit));
-        
+
         // 모임 - 모집 매핑
         plubbing.addRecruit(recruit);
+    }
+
+    private void connectSubCategories(CreatePlubbingRequest createPlubbingRequest, Plubbing plubbing) {
+        // 서브 카테고리 가져오기
+        List<SubCategory> subCategories = createPlubbingRequest.subCategories()
+                .stream()
+                .map(categoryService::getSubCategory)
+                .toList();
+
+        // 서브 카테고리 - 모임 매핑 (plubbingSubCategory 엔티티 생성)
+        List<PlubbingSubCategory> plubbingSubCategories = subCategories.stream()
+                .map(subCategory -> PlubbingSubCategory.builder()
+                        .subCategory(subCategory)
+                        .plubbing(plubbing)
+                        .build())
+                .toList();
+
+        // 플러빙 객체에 추가 - 더티체킹으로 자동 엔티티 저장
+        plubbing.addPlubbingSubCategories(plubbingSubCategories);
+    }
+
+
+    @Transactional
+    public PlubbingResponse createPlubbing(CreatePlubbingRequest createPlubbingRequest) {
+        // 모임 생성자(호스트) 가져오기
+//        Account owner = accountService.getCurrentAccount();
+        Account owner = accountRepository.save(Account.builder().email("test@test.com").build()); // for test
+
+        // Plubbing 엔티티 생성 및 저장
+        Plubbing plubbing = plubbingRepository.save(
+                Plubbing.builder()
+                        .name(createPlubbingRequest.name())
+                        .goal(createPlubbingRequest.goal())
+                        .mainImageFileName(uploadMainImage(createPlubbingRequest, owner))
+                        .status(PlubbingStatus.ACTIVE)
+                        .onOff(createPlubbingRequest.getOnOff())
+                        .maxAccountNum(createPlubbingRequest.maxAccountNum())
+                        .build()
+        );
+
+        // days 매핑
+        plubbing.addPlubbingMeetingDay(createPlubbingRequest.getPlubbingMeetingDay(plubbing));
+
+        // 오프라인이면 장소도 저장 (온라인 이면 기본값 저장)
+        switch (plubbing.getOnOff().name()) {
+            case "OFF" -> plubbing.addPlubbingPlace(PlubbingPlace.builder()
+                    .address(createPlubbingRequest.address())
+                    .placePositionX(createPlubbingRequest.placePositionX())
+                    .placePositionY(createPlubbingRequest.placePositionY())
+                    .build());
+
+            case "ON" -> plubbing.addPlubbingPlace(new PlubbingPlace());
+        }
+
+        // Plubbing - PlubbingSubCategory 매핑
+        connectSubCategories(createPlubbingRequest, plubbing);
+
+        // Plubbing - AccountPlubbing 매핑
+        plubbing.addAccountPlubbing(AccountPlubbing.builder()
+                .isHost(true)
+                .account(owner)
+                .plubbing(plubbing)
+                .accountPlubbingStatus(AccountPlubbingStatus.ACTIVE)
+                .build()
+        );
+
+        // 모집 자동 생성 및 매핑
+        createRecruit(createPlubbingRequest, plubbing);
 
         plubbingRepository.flush(); // flush를 안 하면 recruitId가 null로 들어감
-        
+
         return PlubbingResponse.of(plubbing);
     }
+
+
 }

--- a/src/main/java/plub/plubserver/domain/plubbing/service/PlubbingService.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/service/PlubbingService.java
@@ -77,7 +77,6 @@ public class PlubbingService {
                         .goal(createPlubbingRequest.goal())
                         .mainImageFileName(mainImgFileName)
                         .status(PlubbingStatus.ACTIVE)
-                        .days(createPlubbingRequest.days())
                         .onOff(createPlubbingRequest.getOnOff())
                         .maxAccountNum(createPlubbingRequest.maxAccountNum())
                         .plubbingDateList(new ArrayList<>())
@@ -86,6 +85,10 @@ public class PlubbingService {
                         .timeLineList(new ArrayList<>())
                         .build()
         );
+
+        plubbingRepository.flush();
+        // days 매핑
+        plubbing.addPlubbingMeetingDay(createPlubbingRequest.getPlubbingMeetingDay(plubbing));
         
         // 오프라인이면 장소도 저장 (온라인 이면 기본값 저장)
         switch (plubbing.getOnOff().name()) {

--- a/src/main/java/plub/plubserver/domain/plubbing/service/PlubbingService.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/service/PlubbingService.java
@@ -58,8 +58,8 @@ public class PlubbingService {
     @Transactional
     public PlubbingResponse createPlubbing(CreatePlubbingRequest createPlubbingRequest) {
         // 모임 생성자(호스트) 가져오기
-        Account owner = accountService.getCurrentAccount();
-//        Account owner = accountRepository.save(Account.builder().email("test@test.com").build()); // for test
+//        Account owner = accountService.getCurrentAccount();
+        Account owner = accountRepository.save(Account.builder().email("test@test.com").build()); // for test
 
         // 메인 이미지 업로드 (선택 했을 시)
         String mainImgFileName = null;
@@ -87,12 +87,15 @@ public class PlubbingService {
                         .build()
         );
         
-        // 오프라인이면 장소도 저장
-        if (plubbing.getOnOff().name().equals("OFF")) {
-            plubbing.addPlubbingPlace(PlubbingPlace.builder()
-                            .placePositionX(createPlubbingRequest.placePositionX())
-                            .placePositionY(createPlubbingRequest.placePositionY())
-                            .build());
+        // 오프라인이면 장소도 저장 (온라인 이면 기본값 저장)
+        switch (plubbing.getOnOff().name()) {
+            case "OFF" -> plubbing.addPlubbingPlace(PlubbingPlace.builder()
+                        .address(createPlubbingRequest.address())
+                        .placePositionX(createPlubbingRequest.placePositionX())
+                        .placePositionY(createPlubbingRequest.placePositionY())
+                        .build());
+
+            case "ON" -> plubbing.addPlubbingPlace(new PlubbingPlace());
         }
 
         // Plubbing - PlubbingSubCategory 매핑

--- a/src/main/java/plub/plubserver/domain/recruit/dto/RecruitDto.java
+++ b/src/main/java/plub/plubserver/domain/recruit/dto/RecruitDto.java
@@ -1,5 +1,29 @@
 package plub.plubserver.domain.recruit.dto;
 
+import lombok.Builder;
+import plub.plubserver.domain.recruit.model.Question;
+import plub.plubserver.domain.recruit.model.Recruit;
+
+import java.util.List;
+
 public class RecruitDto {
-    public record RecruitResponse(){}
+
+    public record RecruitResponse(
+            Long recruitId,
+            String title,
+            String introduce,
+            int questionNum,
+            List<String> questions
+    ){
+        @Builder public RecruitResponse {}
+        public static RecruitResponse of(Recruit recruit) {
+            return RecruitResponse.builder()
+                    .recruitId(recruit.getId())
+                    .title(recruit.getTitle())
+                    .introduce(recruit.getIntroduce())
+                    .questionNum(recruit.getQuestionNum())
+                    .questions(recruit.getQuestions().stream().map(Question::getQuestionTitle).toList())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/plub/plubserver/domain/recruit/model/Question.java
+++ b/src/main/java/plub/plubserver/domain/recruit/model/Question.java
@@ -1,6 +1,7 @@
 package plub.plubserver.domain.recruit.model;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import plub.plubserver.common.model.BaseTimeEntity;
@@ -18,11 +19,20 @@ public class Question extends BaseTimeEntity {
     @Column(name = "question_id")
     private Long id;
 
-    private String title;
-    private String content;
+    private String questionTitle;
 
     // 질문(다) - 모집(1)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
     private Recruit recruit;
+
+    @Builder
+    public Question(String questionTitle, Recruit recruit) {
+        this.questionTitle = questionTitle;
+        this.recruit = recruit;
+    }
+
+    public void addRecruit(Recruit recruit) {
+        this.recruit = recruit;
+    }
 }

--- a/src/main/java/plub/plubserver/domain/recruit/model/Recruit.java
+++ b/src/main/java/plub/plubserver/domain/recruit/model/Recruit.java
@@ -1,6 +1,7 @@
 package plub.plubserver.domain.recruit.model;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import plub.plubserver.common.model.BaseTimeEntity;
@@ -18,7 +19,7 @@ public class Recruit extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "board_id")
+    @Column(name = "recruit_id")
     private Long id;
 
     private String title; // 소개글 제목 - 모집 페이지에서 제일 크게 보여줄 제목
@@ -37,4 +38,13 @@ public class Recruit extends BaseTimeEntity {
     @OneToMany(mappedBy = "recruit", cascade = CascadeType.ALL)
     private List<Question> questions = new ArrayList<>();
 
+    @Builder
+    public Recruit(String title, String introduce, int questionNum, List<AccountRecruit> accountRecruitList, Plubbing plubbing, List<Question> questions) {
+        this.title = title;
+        this.introduce = introduce;
+        this.questionNum = questionNum;
+        this.accountRecruitList = accountRecruitList;
+        this.plubbing = plubbing;
+        this.questions = questions;
+    }
 }


### PR DESCRIPTION
## 관련 이슈
- X

## 구현한 내용 또는 수정한 내용
- 모임 생성시 모집글이 자동으로 생성되어 저장

## 추가적으로 알리고 싶은 내용
- 모임 생성 로직이 길다보니까 중간에 flush를 호출해주지 않으면 Recruit 객체가 영속화 되지 않아서 (id가 null로 들어감) 중간에 flush를 호출해 줬습니다.
![flush](https://user-images.githubusercontent.com/85692623/203561401-9af5b60b-1f3c-4c11-9a27-fb6bb170b83b.png)

### 회원가입 없이 모임 생성 테스트 하기
1. SecurityConfig에서 모임 관련 엔드포인트를 전부 허용 합니다.
![permit](https://user-images.githubusercontent.com/85692623/203561811-ba0022b8-c6a8-4900-aacc-9e49c2fbb163.png)

2. PlubbingService의 createPlubbing 함수에서 더미 회원 저장 코드를 주석 해제합니다.
![te](https://user-images.githubusercontent.com/85692623/203562013-d1a911e8-ecc7-438e-a0fd-00e4361b8296.png)


## TODO / 고민하고 있는 것들  
- flush 호출 없이 작성하고 싶은데 혹시 좋은 아이디어 있으신가요?
- 서버를 재시작하고 회원 가입하고 테스트를 진행하는게 너무 번거롭습니다... 개선할 수 없을까요??
