### PR TITLE
[PLUB-192] 신고 통합 및 회원 정지 API

### DIFF
--- a/src/main/java/plub/plubserver/common/exception/StatusCode.java
+++ b/src/main/java/plub/plubserver/common/exception/StatusCode.java
@@ -82,6 +82,7 @@ public enum StatusCode {
     REPORT_TARGET_NOT_FOUND(404, 5030, "report target not found."),
     DUPLICATE_REPORT(400, 5040, "duplicate report."),
     INVALID_ACCOUNT_STATUS(400, 5050, "invalid account status."),
+    TOO_MANY_REPORTS(400, 5060, "too many reports."),
     /**
      * Plubbing
      */

--- a/src/main/java/plub/plubserver/common/exception/StatusCode.java
+++ b/src/main/java/plub/plubserver/common/exception/StatusCode.java
@@ -77,7 +77,9 @@ public enum StatusCode {
      * Report
      */
     NOT_FOUND_REPORT(404, 5000, "not found report error."),
-
+    NOT_FOUND_SUSPEND_ACCOUNT(404, 5010, "not found suspend account error."),
+    CANNOT_CHANGE_PERMANENTLY_BANNED_ACCOUNT(400, 5020, "cannot change permanently banned account."),
+    REPORT_TARGET_NOT_FOUND(404, 5030, "report target not found."),
     /**
      * Plubbing
      */
@@ -99,6 +101,7 @@ public enum StatusCode {
     ALREADY_ACCEPTED(400, 6100, "this applicant is already accepted."),
     ALREADY_REJECTED(400, 6110, "this applicant is already rejected."),
     PLUBBING_MEMBER_FULL(400, 6120, "plubbing member is full."),
+    NOT_FOUND_RECRUIT(404, 6130, "not found recruit error."),
 
     /**
      * Todo

--- a/src/main/java/plub/plubserver/common/exception/StatusCode.java
+++ b/src/main/java/plub/plubserver/common/exception/StatusCode.java
@@ -80,6 +80,8 @@ public enum StatusCode {
     NOT_FOUND_SUSPEND_ACCOUNT(404, 5010, "not found suspend account error."),
     CANNOT_CHANGE_PERMANENTLY_BANNED_ACCOUNT(400, 5020, "cannot change permanently banned account."),
     REPORT_TARGET_NOT_FOUND(404, 5030, "report target not found."),
+    DUPLICATE_REPORT(400, 5040, "duplicate report."),
+    INVALID_ACCOUNT_STATUS(400, 5050, "invalid account status."),
     /**
      * Plubbing
      */

--- a/src/main/java/plub/plubserver/common/exception/StatusCode.java
+++ b/src/main/java/plub/plubserver/common/exception/StatusCode.java
@@ -26,6 +26,7 @@ public enum StatusCode {
     SOCIAL_TYPE_ERROR(400, 2030, "invalid social type error."),
     ROLE_ACCESS_ERROR(400, 2040, "role access error."),
     NICKNAME_ERROR(400, 2050, "invalid nickname error."),
+    SELF_REPORT_ERROR(400, 2060, "self report error."),
 
     /**
      * Auth

--- a/src/main/java/plub/plubserver/common/exception/StatusCode.java
+++ b/src/main/java/plub/plubserver/common/exception/StatusCode.java
@@ -16,6 +16,10 @@ public enum StatusCode {
     AWS_S3_UPLOAD_FAIL(400, 9040, "AWS S3 upload fail."),
     AWS_S3_DELETE_FAIL(400, 9050, "AWS S3 delete fail."),
     AWS_S3_FILE_SIZE_EXCEEDED(400, 9060, "exceeded file size."),
+    PAUSED_ACCOUNT(400, 9070, "paused account error."),
+    BANNED_ACCOUNT(400, 9080, "banned account error."),
+    PERMANENTLY_BANNED_ACCOUNT(400, 9090, "permanently banned account error."),
+
 
     /**
      * Account
@@ -27,6 +31,7 @@ public enum StatusCode {
     ROLE_ACCESS_ERROR(400, 2040, "role access error."),
     NICKNAME_ERROR(400, 2050, "invalid nickname error."),
     SELF_REPORT_ERROR(400, 2060, "self report error."),
+    SUSPENDED_ACCOUNT(400, 2070, "suspended account error."),
 
     /**
      * Auth
@@ -83,6 +88,7 @@ public enum StatusCode {
     DUPLICATE_REPORT(400, 5040, "duplicate report."),
     INVALID_ACCOUNT_STATUS(400, 5050, "invalid account status."),
     TOO_MANY_REPORTS(400, 5060, "too many reports."),
+    ALREADY_REVOKE_SUSPEND_ACCOUNT(400, 5070, "already revoke suspend account."),
     /**
      * Plubbing
      */

--- a/src/main/java/plub/plubserver/config/jwt/JwtProvider.java
+++ b/src/main/java/plub/plubserver/config/jwt/JwtProvider.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.Optional;
 
 import static plub.plubserver.domain.account.dto.AuthDto.SigningAccount;
+import static plub.plubserver.domain.account.service.AuthService.checkAccountStatus;
 
 @Component
 @Slf4j
@@ -36,7 +37,8 @@ public class JwtProvider {
     public JwtProvider(@Value("${jwt.secret-key}") String secretKey,
                        PrincipalDetailService principalDetailService,
                        RefreshTokenRepository refreshTokenRepository,
-                       CustomEncryptUtil customEncryptUtil) {
+                       CustomEncryptUtil customEncryptUtil
+    ) {
         this.privateKey = Keys.hmacShaKeyFor(secretKey.getBytes());
         this.principalDetailService = principalDetailService;
         this.refreshTokenRepository = refreshTokenRepository;
@@ -178,11 +180,10 @@ public class JwtProvider {
         }
         RefreshToken findRefreshToken = refreshTokenRepository
                 .findByRefreshToken(refreshToken)
-                .orElseThrow(
-                        () -> new AuthException(StatusCode.NOT_FOUND_REFRESH_TOKEN)
-                );
+                .orElseThrow(() -> new AuthException(StatusCode.NOT_FOUND_REFRESH_TOKEN));
 
         Account account = findRefreshToken.getAccount();
+        checkAccountStatus(account);
         String newAccessToken = createAccessToken(account);
         String newRefreshToken = createRefreshToken(account);
 

--- a/src/main/java/plub/plubserver/domain/account/controller/AccountController.java
+++ b/src/main/java/plub/plubserver/domain/account/controller/AccountController.java
@@ -7,7 +7,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import plub.plubserver.common.dto.ApiResponse;
-import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.account.service.AccountService;
 
 import javax.validation.Valid;
@@ -15,8 +14,6 @@ import javax.validation.Valid;
 import static plub.plubserver.common.dto.ApiResponse.success;
 import static plub.plubserver.domain.account.dto.AccountDto.*;
 import static plub.plubserver.domain.account.dto.AuthDto.AuthMessage;
-import static plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
-import static plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
 
 
 @RestController
@@ -98,16 +95,6 @@ public class AccountController {
             @PageableDefault(size = 10) Pageable pageable
     ) {
         return success(accountService.searchAccountList(startedAt, endedAt, keyword, pageable));
-    }
-
-    @ApiOperation(value = "회원 신고")
-    @PostMapping("/{accountId}/report")
-    public ApiResponse<ReportResponse> reportAccount(
-            @PathVariable Long accountId,
-            @Valid @RequestBody CreateReportRequest createReportRequest
-    ) {
-        Account loginAccount = accountService.getCurrentAccount();
-        return success(accountService.reportAccount(loginAccount, accountId, createReportRequest));
     }
 }
 

--- a/src/main/java/plub/plubserver/domain/account/controller/AccountController.java
+++ b/src/main/java/plub/plubserver/domain/account/controller/AccountController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import plub.plubserver.common.dto.ApiResponse;
+import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.account.service.AccountService;
 
 import javax.validation.Valid;
@@ -14,6 +15,8 @@ import javax.validation.Valid;
 import static plub.plubserver.common.dto.ApiResponse.success;
 import static plub.plubserver.domain.account.dto.AccountDto.*;
 import static plub.plubserver.domain.account.dto.AuthDto.AuthMessage;
+import static plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
+import static plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
 
 
 @RestController
@@ -96,4 +99,16 @@ public class AccountController {
     ) {
         return success(accountService.searchAccountList(startedAt, endedAt, keyword, pageable));
     }
+
+    @ApiOperation(value = "회원 신고")
+    @PostMapping("/{accountId}/report")
+    public ApiResponse<ReportResponse> reportAccount(
+            @PathVariable Long accountId,
+            @Valid @RequestBody CreateReportRequest createReportRequest
+    ) {
+        Account loginAccount = accountService.getCurrentAccount();
+        return success(accountService.reportAccount(loginAccount, accountId, createReportRequest));
+    }
 }
+
+

--- a/src/main/java/plub/plubserver/domain/account/controller/AccountController.java
+++ b/src/main/java/plub/plubserver/domain/account/controller/AccountController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 import plub.plubserver.common.dto.ApiResponse;
+import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.account.service.AccountService;
 
 import javax.validation.Valid;
@@ -95,6 +96,25 @@ public class AccountController {
             @PageableDefault(size = 10) Pageable pageable
     ) {
         return success(accountService.searchAccountList(startedAt, endedAt, keyword, pageable));
+    }
+
+    @ApiOperation(value = "회원 상태 변경")
+    @PutMapping("/{accountId}/changeStatus")
+    public ApiResponse<AccountIdResponse> updateAccountStatus(
+            @PathVariable Long accountId,
+            @RequestParam String status
+    ) {
+        Account currentAccount = accountService.getCurrentAccount();
+        return success(accountService.updateAccountStatus(currentAccount, accountId, status));
+    }
+
+    @ApiOperation(value = "회원 영구 정지 해제")
+    @PutMapping("/{accountId}/unSuspend")
+    public ApiResponse<AccountIdResponse> unSuspendAccount(
+            @PathVariable Long accountId
+    ) {
+        Account currentAccount = accountService.getCurrentAccount();
+        return success(accountService.unSuspendAccount(currentAccount, accountId));
     }
 }
 

--- a/src/main/java/plub/plubserver/domain/account/dto/AccountDto.java
+++ b/src/main/java/plub/plubserver/domain/account/dto/AccountDto.java
@@ -165,5 +165,13 @@ public class AccountDto {
             boolean isReceivedPushNotification
     ) {
     }
+
+    public record AccountIdResponse(
+            Long accountId
+    ) {
+        public static AccountIdResponse of(Account account) {
+            return new AccountIdResponse(account.getId());
+        }
+    }
 }
 

--- a/src/main/java/plub/plubserver/domain/account/model/Account.java
+++ b/src/main/java/plub/plubserver/domain/account/model/Account.java
@@ -134,8 +134,12 @@ public class Account extends BaseEntity {
     private List<TodoTimeline> timeLineList = new ArrayList<>();
 
     // 회원(1) - 신고(다)
-    @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "reporter", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Report> reportList = new ArrayList<>();
+
+    // 회원(1) - 신고 됨(다)
+    @OneToMany(mappedBy = "reportedAccount", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Report> reportedList = new ArrayList<>();
 
     // 회원(1) - 투두 좋아요(다)
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -224,10 +228,6 @@ public class Account extends BaseEntity {
         }
     }
 
-    public void addReport(Report report) {
-        if (reportList == null) reportList = new ArrayList<>();
-        reportList.add(report);
-    }
 
     public void updateFcmToken(String newFcmToken) {
         this.fcmToken = newFcmToken;
@@ -235,5 +235,9 @@ public class Account extends BaseEntity {
 
     public void updatePushNotificationStatus(boolean pushNotificationStatus) {
         this.isReceivedPushNotification = pushNotificationStatus;
+    }
+
+    public void updateAccountStatus(AccountStatus accountStatus) {
+        this.accountStatus = accountStatus;
     }
 }

--- a/src/main/java/plub/plubserver/domain/account/model/Account.java
+++ b/src/main/java/plub/plubserver/domain/account/model/Account.java
@@ -64,6 +64,9 @@ public class Account extends BaseEntity {
     private AccountStatus accountStatus;
 
     private LocalDateTime joinDate;
+    private LocalDateTime lastLoginDate;
+    private LocalDateTime pausedStartDate;
+    private LocalDateTime pausedEndDate;
 
     // 회원(1) - 차단 사용자(다)
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -111,7 +114,7 @@ public class Account extends BaseEntity {
 
     // 회원(1) - 공지 좋아요(다)
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<NoticeLike>  noticeLikeList = new ArrayList<>();
+    private List<NoticeLike> noticeLikeList = new ArrayList<>();
 
     // 회원(1) - 공지 댓글(다)
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -239,5 +242,10 @@ public class Account extends BaseEntity {
 
     public void updateAccountStatus(AccountStatus accountStatus) {
         this.accountStatus = accountStatus;
+    }
+
+    public void setPausedDate() {
+        this.pausedStartDate = LocalDateTime.now();
+        this.pausedEndDate = LocalDateTime.now().plusMonths(1);
     }
 }

--- a/src/main/java/plub/plubserver/domain/account/model/AccountStatus.java
+++ b/src/main/java/plub/plubserver/domain/account/model/AccountStatus.java
@@ -1,6 +1,6 @@
 package plub.plubserver.domain.account.model;
 
 public enum AccountStatus {
-    // 정상, 차단
-    NORMAL, BLOCKED
+    // 정상, 일시 정지, 정지, 영구 정지
+    NORMAL, PAUSED, BANNED, PERMANENTLY_BANNED
 }

--- a/src/main/java/plub/plubserver/domain/account/model/SuspendAccount.java
+++ b/src/main/java/plub/plubserver/domain/account/model/SuspendAccount.java
@@ -1,0 +1,36 @@
+package plub.plubserver.domain.account.model;
+
+
+import lombok.*;
+import plub.plubserver.common.model.BaseEntity;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class SuspendAccount extends BaseEntity {
+    @Id
+    @GeneratedValue
+    @Column(name = "suspend_account_id")
+    private Long id;
+    private LocalDateTime startedSuspendedDate;
+    private LocalDateTime endedSuspendedDate;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    private boolean isSuspended;
+
+    public void setSuspendedDate() {
+        this.startedSuspendedDate = LocalDateTime.now();
+        this.endedSuspendedDate = LocalDateTime.now().plusMonths(6);
+    }
+
+    public void setSuspended(boolean suspended) {
+        isSuspended = suspended;
+    }
+}

--- a/src/main/java/plub/plubserver/domain/account/model/SuspendAccount.java
+++ b/src/main/java/plub/plubserver/domain/account/model/SuspendAccount.java
@@ -19,9 +19,9 @@ public class SuspendAccount extends BaseEntity {
     private Long id;
     private LocalDateTime startedSuspendedDate;
     private LocalDateTime endedSuspendedDate;
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "account_id")
-    private Account account;
+    private Long accountId;
+    private String accountEmail;
+    private String accountDI;
 
     private boolean isSuspended;
 

--- a/src/main/java/plub/plubserver/domain/account/repository/SuspendAccountRepository.java
+++ b/src/main/java/plub/plubserver/domain/account/repository/SuspendAccountRepository.java
@@ -1,0 +1,12 @@
+package plub.plubserver.domain.account.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import plub.plubserver.domain.account.model.Account;
+import plub.plubserver.domain.account.model.SuspendAccount;
+
+import java.util.Optional;
+
+public interface SuspendAccountRepository extends JpaRepository<SuspendAccount, Long> {
+
+    Optional<SuspendAccount> findByAccount(Account account);
+}

--- a/src/main/java/plub/plubserver/domain/account/repository/SuspendAccountRepository.java
+++ b/src/main/java/plub/plubserver/domain/account/repository/SuspendAccountRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface SuspendAccountRepository extends JpaRepository<SuspendAccount, Long> {
     Optional<SuspendAccount> findByAccountId(Long accountId);
+    Optional<SuspendAccount> findByAccountEmail(String email);
 }

--- a/src/main/java/plub/plubserver/domain/account/repository/SuspendAccountRepository.java
+++ b/src/main/java/plub/plubserver/domain/account/repository/SuspendAccountRepository.java
@@ -1,12 +1,10 @@
 package plub.plubserver.domain.account.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.account.model.SuspendAccount;
 
 import java.util.Optional;
 
 public interface SuspendAccountRepository extends JpaRepository<SuspendAccount, Long> {
-
-    Optional<SuspendAccount> findByAccount(Account account);
+    Optional<SuspendAccount> findByAccountId(Long accountId);
 }

--- a/src/main/java/plub/plubserver/domain/account/service/AccountService.java
+++ b/src/main/java/plub/plubserver/domain/account/service/AccountService.java
@@ -157,8 +157,10 @@ public class AccountService {
         SuspendAccount suspendAccount = suspendAccountRepository.findByAccountId(accountId)
                 .orElseThrow(() -> new ReportException(StatusCode.NOT_FOUND_SUSPEND_ACCOUNT));
         suspendAccount.setSuspended(false);
-        suspendAccount.getAccount().updateAccountStatus(NORMAL);
-        return AccountIdResponse.of(suspendAccount.getAccount());
+        Account account = accountRepository.findById(suspendAccount.getAccountId())
+                .orElseThrow(() -> new ReportException(StatusCode.ALREADY_REVOKE_SUSPEND_ACCOUNT));
+        account.updateAccountStatus(NORMAL);
+        return AccountIdResponse.of(account);
     }
 
     // 회원 상태 변경
@@ -225,7 +227,9 @@ public class AccountService {
 
     private SuspendAccount createSuspendAccount(Account account) {
         return SuspendAccount.builder()
-                .account(account)
+                .accountId(account.getId())
+                .accountEmail(account.getEmail())
+                .accountDI(account.getEmail().split("@")[0])
                 .isSuspended(true)
                 .build();
     }

--- a/src/main/java/plub/plubserver/domain/account/service/AccountService.java
+++ b/src/main/java/plub/plubserver/domain/account/service/AccountService.java
@@ -147,17 +147,4 @@ public class AccountService {
         Page<AccountInfoWeb> accountList = accountRepository.findBySearch(startedAt, endedAt, keyword, pageable).map(AccountInfoWeb::of);
         return AccountListResponse.of(accountList);
     }
-
-    /**
-     * 회원 신고
-     */
-    @Transactional
-    public ReportResponse reportAccount(Account reporter, Long accountId, CreateReportRequest createReportRequest) {
-        Account ReportedAccount = getAccount(accountId);
-        if (ReportedAccount.getId().equals(reporter.getId())) {
-            throw new AccountException(StatusCode.SELF_REPORT_ERROR);
-        }
-        Report report = reportService.createReport(createReportRequest, reporter);
-        return reportService.notifyAccount(report, ReportedAccount);
-    }
 }

--- a/src/main/java/plub/plubserver/domain/account/service/AccountService.java
+++ b/src/main/java/plub/plubserver/domain/account/service/AccountService.java
@@ -13,7 +13,7 @@ import plub.plubserver.domain.account.repository.SuspendAccountRepository;
 import plub.plubserver.domain.category.exception.CategoryException;
 import plub.plubserver.domain.category.model.SubCategory;
 import plub.plubserver.domain.category.repository.SubCategoryRepository;
-import plub.plubserver.domain.notification.service.NotificationService;
+import plub.plubserver.domain.report.config.ReportStatusMessage;
 import plub.plubserver.domain.report.exception.ReportException;
 import plub.plubserver.domain.report.service.ReportService;
 
@@ -41,8 +41,6 @@ public class AccountService {
 
     private final ReportService reportService;
     private final SuspendAccountRepository suspendAccountRepository;
-    private final NotificationService notificationService;
-
 
     // 회원 정보 조회
     public AccountInfoResponse getMyAccount() {
@@ -188,23 +186,40 @@ public class AccountService {
     private void handlePermanentlyBannedStatus(Account reportedAccount, String status, Account loginAccount) {
         AccountStatus accountStatus = AccountStatus.valueOf(status);
         switch (accountStatus) {
-            case PERMANENTLY_BANNED:
+            case PERMANENTLY_BANNED -> {
                 SuspendAccount suspendAccount = createSuspendAccount(reportedAccount);
                 suspendAccount.setSuspendedDate();
                 suspendAccountRepository.save(suspendAccount);
-                reportService.adminReportAccount(loginAccount, reportedAccount, REPORT_ACCOUNT_BAN_CONTENT, BAN_PERMANENTLY);
-                break;
-            case BANNED:
-                reportService.adminReportAccount(loginAccount, reportedAccount, REPORT_ACCOUNT_BAN_CONTENT, BAN_ONE_MONTH);
-                break;
-            case PAUSED:
-                reportService.adminReportAccount(loginAccount, reportedAccount, REPORT_ACCOUNT_PAUSED_CONTENT, BAN_ONE_MONTH);
-                break;
-            case NORMAL:
-                reportService.adminReportAccount(loginAccount, reportedAccount, REPORT_ACCOUNT_WARING_CONTENT, UNBAN);
-                break;
-            default:
-                throw new ReportException(StatusCode.INVALID_ACCOUNT_STATUS);
+                reportService.adminReportAccount(
+                        loginAccount,
+                        reportedAccount,
+                        REPORT_TITLE_ADMIN,
+                        ReportStatusMessage.PERMANENTLY_BANNED,
+                        BAN_PERMANENTLY
+                );
+            }
+            case BANNED -> reportService.adminReportAccount(
+                    loginAccount,
+                    reportedAccount,
+                    REPORT_TITLE_ADMIN,
+                    ReportStatusMessage.BANNED,
+                    BAN_ONE_MONTH
+            );
+            case PAUSED -> reportService.adminReportAccount(
+                    loginAccount,
+                    reportedAccount,
+                    REPORT_TITLE_ADMIN,
+                    ReportStatusMessage.PAUSED,
+                    BAN_ONE_MONTH
+            );
+            case NORMAL -> reportService.adminReportAccount(
+                    loginAccount,
+                    reportedAccount,
+                    REPORT_TITLE_ADMIN,
+                    ReportStatusMessage.NORMAL,
+                    UNBAN
+            );
+            default -> throw new ReportException(StatusCode.INVALID_ACCOUNT_STATUS);
         }
     }
 

--- a/src/main/java/plub/plubserver/domain/archive/controller/ArchiveController.java
+++ b/src/main/java/plub/plubserver/domain/archive/controller/ArchiveController.java
@@ -15,8 +15,6 @@ import plub.plubserver.domain.archive.dto.ArchiveDto.ArchiveIdResponse;
 import plub.plubserver.domain.archive.dto.ArchiveDto.ArchiveRequest;
 import plub.plubserver.domain.archive.dto.ArchiveDto.ArchiveResponse;
 import plub.plubserver.domain.archive.service.ArchiveService;
-import plub.plubserver.domain.report.dto.ReportDto;
-import plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
 
 import javax.validation.Valid;
 
@@ -87,16 +85,5 @@ public class ArchiveController {
         return success(
                 archiveService.softDeleteArchive(loginAccount, plubbingId, archiveId)
         );
-    }
-
-    @ApiOperation(value = "아카이브 신고")
-    @PostMapping("/{archiveId}/reports")
-    public ApiResponse<ReportResponse> reportArchive(
-            @PathVariable Long plubbingId,
-            @PathVariable Long archiveId,
-            @Valid @RequestBody ReportDto.CreateReportRequest createReportRequest
-    ) {
-        Account loginAccount = accountService.getCurrentAccount();
-        return success(archiveService.reportArchive(loginAccount, plubbingId, createReportRequest, archiveId));
     }
 }

--- a/src/main/java/plub/plubserver/domain/archive/service/ArchiveService.java
+++ b/src/main/java/plub/plubserver/domain/archive/service/ArchiveService.java
@@ -20,9 +20,6 @@ import plub.plubserver.domain.archive.model.ArchiveImage;
 import plub.plubserver.domain.archive.repository.ArchiveRepository;
 import plub.plubserver.domain.plubbing.model.Plubbing;
 import plub.plubserver.domain.plubbing.service.PlubbingService;
-import plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
-import plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
-import plub.plubserver.domain.report.model.Report;
 import plub.plubserver.domain.report.service.ReportService;
 
 import java.util.List;
@@ -191,18 +188,5 @@ public class ArchiveService {
     @Transactional
     public void hardDeleteArchive(Long archiveId) {
         archiveRepository.deleteById(archiveId);
-    }
-
-
-    /**
-     * 아카이브 신고
-     */
-    @Transactional
-    public ReportResponse reportArchive(Account reporter, Long plubbingId, CreateReportRequest createReportRequest, Long archiveId) {
-        Plubbing plubbing = plubbingService.getPlubbing(plubbingId);
-        plubbingService.checkMember(reporter, plubbing);
-        Archive archive = getArchive(archiveId); // 아카이브 존재 여부 확인
-        Report report = reportService.createReport(createReportRequest, reporter);
-        return reportService.notifyHost(report, archive.getPlubbing());
     }
 }

--- a/src/main/java/plub/plubserver/domain/notification/controller/NotificationController.java
+++ b/src/main/java/plub/plubserver/domain/notification/controller/NotificationController.java
@@ -3,6 +3,8 @@ package plub.plubserver.domain.notification.controller;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import plub.plubserver.common.dto.ApiResponse;
+import plub.plubserver.domain.account.model.Account;
+import plub.plubserver.domain.account.service.AccountService;
 import plub.plubserver.domain.notification.dto.NotificationDto.NotificationListResponse;
 import plub.plubserver.domain.notification.dto.NotificationDto.NotificationResponse;
 import plub.plubserver.domain.notification.service.NotificationService;
@@ -14,15 +16,18 @@ import static plub.plubserver.common.dto.ApiResponse.success;
 @RequestMapping("/api/notifications")
 public class NotificationController {
     private final NotificationService notificationService;
+    private final AccountService accountService;
 
     @GetMapping("/accounts/me")
     public ApiResponse<NotificationListResponse> getMyNotifications() {
-        return success(notificationService.getMyNotifications());
+        Account currentAccount = accountService.getCurrentAccount();
+        return success(notificationService.getMyNotifications(currentAccount));
     }
 
     @PutMapping("/{notificationId}/read")
     public ApiResponse<NotificationResponse> readNotification(@PathVariable Long notificationId) {
-        return success(notificationService.readNotification(notificationId));
+        Account currentAccount = accountService.getCurrentAccount();
+        return success(notificationService.readNotification(notificationId, currentAccount));
     }
 
 

--- a/src/main/java/plub/plubserver/domain/plubbing/controller/PlubbingController.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/controller/PlubbingController.java
@@ -15,8 +15,6 @@ import plub.plubserver.domain.plubbing.dto.PlubbingDto.*;
 import plub.plubserver.domain.plubbing.service.PlubbingService;
 import plub.plubserver.domain.recruit.dto.RecruitDto.UpdateRecruitQuestionRequest;
 import plub.plubserver.domain.recruit.dto.RecruitDto.UpdateRecruitRequest;
-import plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
-import plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
 
 import javax.validation.Valid;
 
@@ -126,15 +124,5 @@ public class PlubbingController {
             @RequestParam("status") String status
     ) {
         return success(plubbingService.getMyPlubbingByStatus(status));
-    }
-
-    @ApiOperation(value = "모임 신고")
-    @PostMapping("/{plubbingId}/reports")
-    public ApiResponse<ReportResponse> reportPlubbing(
-            @PathVariable Long plubbingId,
-            @Valid @RequestBody CreateReportRequest createReportRequest
-    ) {
-        Account loginAccount = accountService.getCurrentAccount();
-        return success(plubbingService.reportPlubbing(createReportRequest, loginAccount));
     }
 }

--- a/src/main/java/plub/plubserver/domain/plubbing/service/PlubbingService.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/service/PlubbingService.java
@@ -29,9 +29,6 @@ import plub.plubserver.domain.recruit.model.*;
 import plub.plubserver.domain.recruit.repository.AppliedAccountRepository;
 import plub.plubserver.domain.recruit.repository.BookmarkRepository;
 import plub.plubserver.domain.recruit.repository.RecruitRepository;
-import plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
-import plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
-import plub.plubserver.domain.report.model.Report;
 import plub.plubserver.domain.report.service.ReportService;
 
 import java.util.ArrayList;
@@ -437,16 +434,6 @@ public class PlubbingService {
 
     public Boolean isBookmarked(Account account, Plubbing plubbing) {
         return bookmarkRepository.existsByAccountAndRecruit(account, plubbing.getRecruit());
-    }
-
-    /**
-     * 모임 신고
-     */
-    @Transactional
-    public ReportResponse reportPlubbing(CreateReportRequest createReportRequest, Account reporter) {
-        Report report = reportService.createReport(createReportRequest, reporter);
-        Plubbing plubbing = getPlubbing(createReportRequest.reportTargetId()); // 존재여부도 확인
-        return reportService.notifyHost(report, plubbing);
     }
 }
 

--- a/src/main/java/plub/plubserver/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/plub/plubserver/domain/recruit/controller/RecruitController.java
@@ -18,10 +18,6 @@ import plub.plubserver.domain.recruit.dto.QuestionDto.QuestionListResponse;
 import plub.plubserver.domain.recruit.dto.RecruitDto.*;
 import plub.plubserver.domain.recruit.model.RecruitSearchType;
 import plub.plubserver.domain.recruit.service.RecruitService;
-import plub.plubserver.domain.report.dto.ReportDto;
-import plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
-
-import javax.validation.Valid;
 
 import static plub.plubserver.common.dto.ApiResponse.success;
 
@@ -126,16 +122,6 @@ public class RecruitController {
     ) {
         Account loginAccount = accountService.getCurrentAccount();
         return success(recruitService.getMyAppliedAccount(loginAccount, plubbingId));
-    }
-
-    @ApiOperation(value = "모집 신고")
-    @PostMapping("/{plubbingId}/recruit/reports")
-    public ApiResponse<ReportResponse> reportRecruit(
-            @PathVariable Long plubbingId,
-            @Valid @RequestBody ReportDto.CreateReportRequest createReportRequest
-    ) {
-        Account loginAccount = accountService.getCurrentAccount();
-        return success(recruitService.reportRecruit(createReportRequest, loginAccount));
     }
 
     @ApiOperation(value = "내 지원서 조회")

--- a/src/main/java/plub/plubserver/domain/recruit/service/RecruitService.java
+++ b/src/main/java/plub/plubserver/domain/recruit/service/RecruitService.java
@@ -31,9 +31,6 @@ import plub.plubserver.domain.recruit.model.*;
 import plub.plubserver.domain.recruit.repository.AppliedAccountRepository;
 import plub.plubserver.domain.recruit.repository.BookmarkRepository;
 import plub.plubserver.domain.recruit.repository.RecruitRepository;
-import plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
-import plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
-import plub.plubserver.domain.report.model.Report;
 import plub.plubserver.domain.report.service.ReportService;
 
 import java.util.ArrayList;
@@ -373,16 +370,5 @@ public class RecruitService {
         plubbing.updateCurAccountNum();
 
         return JoinedAccountsInfoResponse.of(plubbing);
-    }
-
-    /**
-     * 모집 신고
-     */
-    @Transactional
-    public ReportResponse reportRecruit(CreateReportRequest createReportRequest, Account reporter) {
-        // createReportRequest로 받은 id는 모임 id이다. (모집 id를 따로 프론트로 전달X)
-        Recruit recruit = getRecruitByPlubbingId(createReportRequest.reportTargetId()); // 해당 모임id에 해당하는 모집글 존재여부 확인
-        Report report = reportService.createReport(createReportRequest, reporter);
-        return reportService.notifyHost(report, recruit.getPlubbing());
     }
 }

--- a/src/main/java/plub/plubserver/domain/report/config/ReportConstant.java
+++ b/src/main/java/plub/plubserver/domain/report/config/ReportConstant.java
@@ -3,4 +3,8 @@ package plub.plubserver.domain.report.config;
 public class ReportConstant {
     public static final int REPORT_WARNING_PUSH_COUNT = 6;
     public static final int REPORT_PLUBBING_PAUSE_COUNT = 18;
+
+    public static final int REPORT_ACCOUNT_WARNING_PUSH_COUNT = 1;
+    public static final int REPORT_ACCOUNT_PAUSED_COUNT = 3;
+    public static final int REPORT_ACCOUNT_BAN_COUNT = 6;
 }

--- a/src/main/java/plub/plubserver/domain/report/config/ReportMessage.java
+++ b/src/main/java/plub/plubserver/domain/report/config/ReportMessage.java
@@ -5,10 +5,18 @@ public class ReportMessage {
     public static final String REPORT_HOST_NOTIFY = "신고가 접수되었습니다. 신고 누적 6회 이상이라 호스트에게 경고를 보냈습니다.";
     public static final String REPORT_PLUBBING_PAUSED = "신고가 접수되었습니다. 모임장 경고 3회 이상이라 모임이 영구 정지되었습니다.";
 
+    public static final String REPORT_ACCOUNT_WARNING = "신고가 접수되었습니다. 계정 경고 1회 입니다. 3회 시 1달 정지 6회시 영구정지가 됩니다.";
     public static final String REPORT_ACCOUNT_PAUSED = "신고가 접수되었습니다. 계정 경고 3회 이상이라 계정이 정지되었습니다.";
 
     public static final String REPORT_ACCOUNT_BANNED = "신고가 접수되었습니다. 계정 경고 6회 이상이라 계정이 영구 정지되었습니다.";
 
-    public static final String REPORT_ACCOUNT_WARNING = "신고가 접수되었습니다. 계정 경고 1회 입니다. 3회 시 1달 정지 6회시 영구정지가 됩니다.";
+
+    public static final String REPORT_ACCOUNT_WARING_CONTENT = "경고 1회 입니다. 경고 3회 누적시 계정이 1개월 정지 됩니다.";
+
+    public static final String REPORT_ACCOUNT_PAUSED_CONTENT = "경고 3회 누적으로 계정이 1개월 정지 되었습니다.";
+    public static final String REPORT_ACCOUNT_BAN_CONTENT = "경고 6회 누적으로 계정이 영구 정지 되었습니다.";
+
+    public static final String ADMIN_REPORT_ACCOUNT_BAN = "신고가 접수되었습니다. 계정이 영구 정지 되었습니다.";
+
 
 }

--- a/src/main/java/plub/plubserver/domain/report/config/ReportMessage.java
+++ b/src/main/java/plub/plubserver/domain/report/config/ReportMessage.java
@@ -16,7 +16,8 @@ public class ReportMessage {
     public static final String REPORT_ACCOUNT_PAUSED_CONTENT = "경고 3회 누적으로 계정이 1개월 정지 되었습니다.";
     public static final String REPORT_ACCOUNT_BAN_CONTENT = "경고 6회 누적으로 계정이 영구 정지 되었습니다.";
 
-    public static final String ADMIN_REPORT_ACCOUNT_BAN = "신고가 접수되었습니다. 계정이 영구 정지 되었습니다.";
+    public static final String REPORT_TITLE = "신고";
+    public static final String REPORT_TITLE_ADMIN = "검토 완료";
 
 
 }

--- a/src/main/java/plub/plubserver/domain/report/config/ReportMessage.java
+++ b/src/main/java/plub/plubserver/domain/report/config/ReportMessage.java
@@ -4,4 +4,11 @@ public class ReportMessage {
     public static final String REPORT_SUCCESS = "신고가 접수되었습니다.";
     public static final String REPORT_HOST_NOTIFY = "신고가 접수되었습니다. 신고 누적 6회 이상이라 호스트에게 경고를 보냈습니다.";
     public static final String REPORT_PLUBBING_PAUSED = "신고가 접수되었습니다. 모임장 경고 3회 이상이라 모임이 영구 정지되었습니다.";
+
+    public static final String REPORT_ACCOUNT_PAUSED = "신고가 접수되었습니다. 계정 경고 3회 이상이라 계정이 정지되었습니다.";
+
+    public static final String REPORT_ACCOUNT_BANNED = "신고가 접수되었습니다. 계정 경고 6회 이상이라 계정이 영구 정지되었습니다.";
+
+    public static final String REPORT_ACCOUNT_WARNING = "신고가 접수되었습니다. 계정 경고 1회 입니다. 3회 시 1달 정지 6회시 영구정지가 됩니다.";
+
 }

--- a/src/main/java/plub/plubserver/domain/report/config/ReportMessage.java
+++ b/src/main/java/plub/plubserver/domain/report/config/ReportMessage.java
@@ -1,23 +1,52 @@
 package plub.plubserver.domain.report.config;
 
 public class ReportMessage {
-    public static final String REPORT_SUCCESS = "신고가 접수되었습니다.";
-    public static final String REPORT_HOST_NOTIFY = "신고가 접수되었습니다. 신고 누적 6회 이상이라 호스트에게 경고를 보냈습니다.";
-    public static final String REPORT_PLUBBING_PAUSED = "신고가 접수되었습니다. 모임장 경고 3회 이상이라 모임이 영구 정지되었습니다.";
+    public static final String REPORT_FCM_TITLE = "신고";
+    public static final String REPORT_FCM_TITLE_NORMAL = "정지 해제";
 
-    public static final String REPORT_ACCOUNT_WARNING = "신고가 접수되었습니다. 계정 경고 1회 입니다. 3회 시 1달 정지 6회시 영구정지가 됩니다.";
-    public static final String REPORT_ACCOUNT_PAUSED = "신고가 접수되었습니다. 계정 경고 3회 이상이라 계정이 정지되었습니다.";
-
-    public static final String REPORT_ACCOUNT_BANNED = "신고가 접수되었습니다. 계정 경고 6회 이상이라 계정이 영구 정지되었습니다.";
-
-
-    public static final String REPORT_ACCOUNT_WARING_CONTENT = "경고 1회 입니다. 경고 3회 누적시 계정이 1개월 정지 됩니다.";
-
-    public static final String REPORT_ACCOUNT_PAUSED_CONTENT = "경고 3회 누적으로 계정이 1개월 정지 되었습니다.";
-    public static final String REPORT_ACCOUNT_BAN_CONTENT = "경고 6회 누적으로 계정이 영구 정지 되었습니다.";
-
-    public static final String REPORT_TITLE = "신고";
+    public static final String REPORT_FCM_CONTENT_NORMAL_PREFIX = "“";
+    public static final String REPORT_FCM_CONTENT_NORMAL_SUFFIX = "” 님, 이용 정지가 해제되었습니다. PLUB과 함께 즐거운 시간 보내 보아요\uD83D\uDE09";
+    public static final String REPORT_FCM_CONTENT_WARNING_PREFIX = "“";
+    public static final String REPORT_FCM_CONTENT_WARNING_SUFFIX = "님에 대한 신고가 접수되었습니다. 탭을 눌러 자세한 사항을 확인해주세요. ";
+    public static final String REPORT_FCM_CONTENT_PAUSED_PREFIX = "3회 이상 다른 사용자의 신고가 누적되어 “";
+    public static final String REPORT_FCM_CONTENT_PAUSED_SUFFIX = "” 님의 앱 이용이 일시적으로 정지되었습니다. ";
+    public static final String REPORT_FCM_CONTENT_BANNED_PREFIX = "“";
+    public static final String REPORT_FCM_CONTENT_BANNED_SUFFIX = "” 님의 앱 이용이 한 달 간 정지되었습니다. 한 달 후 정지가 해제됩니다. ";
+    public static final String REPORT_FCM_CONTENT_PERMANENTLY_BANNED_PREFIX = "6회 이상 다른 사용자의 신고가 누적되어 “";
+    public static final String REPORT_FCM_CONTENT_PERMANENTLY_BANNED_SUFFIX = "” 님의 앱 이용이 영구정지 되었습니다. 앞으로 앱 이용이 불가한 점 고지드립니다.";
     public static final String REPORT_TITLE_ADMIN = "검토 완료";
+    public static final String REPORT_TITLE_PREFIX = "[신고] “";
+
+    public static final String REPORT_TITLE_NORMAL_SUFFIX = "”님의 이용 정지가 해제되었습니다. ";
+    public static final String REPORT_TITLE_WARNING_SUFFIX = "”님에 대한 신고가 접수되었습니다. ";
+    public static final String REPORT_TITLE_PAUSED_SUFFIX = "”님의 계정이 일시적으로 정지되었습니다. ";
+    public static final String REPORT_TITLE_BANNED_SUFFIX = "”님의 계정이 한 달 간 정지되었습니다. ";
+    public static final String REPORT_TITLE_PERMANENTLY_BANNED_SUFFIX = "”님의 계정이 영구정지 되었습니다. ";
+
+    public static final String REPORT_CONTENT_PREFIX = "“";
+
+    public static final String REPORT_CONTENT_NORMAL_SUFFIX = "” 님, 이용 정지가 해제되었습니다. PLUB과 함께 즐거운 시간 보내 보아요\uD83D\uDE09";
+    public static final String REPORT_CONTENT_WARNING_SUFFIX = "” 를 사유로 신고가 접수되었습니다. 아래 신고 정책을 참고하여 주의 부탁드립니다. 만약 접수된 신고가 허위일 경우, 고객센터에서 문의를 통하여 신고 횟수를 차감하실 수 있습니다. \n" +
+            "\n" +
+            "신고 정책\n" +
+            "1회: 경고\n" +
+            "3회: 한 달 정지\n" +
+            "6회: 영구 정지\n" +
+            "\n" +
+            " 계정이 영구정지 될 경우 재가입 및 재이용이 불가하므로, 접수된 신고가 허위일 경우 사전에 고객센터로 문의주시고 신고 횟수를 차감하시길 권고드립니다.";
+
+    public static final String REPORT_CONTENT_PAUSED_SUFFIX = "“ 님에 대한 신고가 3회 이상 누적되어 계정이 일시적으로 정지되었습니다. 아래 사항을 확인하시고 접수된 신고가 허위일 경우, 고객센터에서 문의를 통하여 정지를 즉시 해제하실 수 있습니다.\n" +
+            "\n" +
+            "신고 사유\n" +
+            "1차: “신고 사유\", “모임 이름\"\n" +
+            "2차: “신고 사유\", “모임 이름\"\n" +
+            "3차: “신고 사유\", “모임 이름\"\n" +
+            "\n" +
+            " 6회 이상 신고되어 계정이 영구정지 될 경우 재가입 및 재이용이 불가합니다. 접수된 신고가 허위일 경우 사전에 고객센터로 문의주시고 신고 횟수를 차감하시길 권고드립니다.";
 
 
+    public static final String REPORT_CONTENT_BANNED_SUFFIX = "“ 님에 대한 신고가 3회 이상 누적되어 계정이 한 달 간 정지되었습니다.  6회 이상 신고되어 계정이 영구정지 될 경우 재가입 및 재이용이 불가합니다. \n" +
+            "\n" +
+            " PLUB은 신뢰할 수 있는 커뮤니티를 지향합니다. 앞으로 이 점 주의하여 활동 부탁드리며, 한 달 후에 뵙겠습니다. ";
+    public static final String REPORT_CONTENT_PERMANENTLY_BANNED_SUFFIX = "“ 님에 대한 다른 사용자의 신고가 6회 이상 누적되어 계정이 영구정지되었습니다.  PLUB 재가입 및 재이용이 불가합니다. 지금까지 PLUB을 이용해주셔서 감사합니다. ";
 }

--- a/src/main/java/plub/plubserver/domain/report/config/ReportStatusMessage.java
+++ b/src/main/java/plub/plubserver/domain/report/config/ReportStatusMessage.java
@@ -1,0 +1,86 @@
+package plub.plubserver.domain.report.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import static plub.plubserver.domain.report.config.ReportMessage.*;
+
+@RequiredArgsConstructor
+@Getter
+public enum ReportStatusMessage {
+
+    NORMAL(
+            REPORT_FCM_TITLE_NORMAL,
+            REPORT_FCM_CONTENT_NORMAL_PREFIX,
+            REPORT_FCM_CONTENT_NORMAL_SUFFIX,
+            REPORT_TITLE_PREFIX,
+            REPORT_TITLE_NORMAL_SUFFIX,
+            REPORT_CONTENT_PREFIX,
+            REPORT_CONTENT_NORMAL_SUFFIX
+    ),
+    WARNING(
+            REPORT_FCM_TITLE,
+            REPORT_FCM_CONTENT_WARNING_PREFIX,
+            REPORT_FCM_CONTENT_WARNING_SUFFIX,
+            REPORT_TITLE_PREFIX,
+            REPORT_TITLE_WARNING_SUFFIX,
+            REPORT_CONTENT_PREFIX,
+            REPORT_CONTENT_WARNING_SUFFIX
+    ),
+    PAUSED(
+            REPORT_FCM_TITLE,
+            REPORT_FCM_CONTENT_PAUSED_PREFIX,
+            REPORT_FCM_CONTENT_PAUSED_SUFFIX,
+            REPORT_TITLE_PREFIX,
+            REPORT_TITLE_PAUSED_SUFFIX,
+            REPORT_CONTENT_PREFIX,
+            REPORT_CONTENT_PAUSED_SUFFIX
+    ),
+    BANNED(
+            REPORT_FCM_TITLE,
+            REPORT_FCM_CONTENT_BANNED_PREFIX,
+            REPORT_FCM_CONTENT_BANNED_SUFFIX,
+            REPORT_TITLE_PREFIX,
+            REPORT_TITLE_BANNED_SUFFIX,
+            REPORT_CONTENT_PREFIX,
+            REPORT_CONTENT_BANNED_SUFFIX
+    ),
+    PERMANENTLY_BANNED(
+            REPORT_FCM_TITLE,
+            REPORT_FCM_CONTENT_PERMANENTLY_BANNED_PREFIX,
+            REPORT_FCM_CONTENT_PERMANENTLY_BANNED_SUFFIX,
+            REPORT_TITLE_PREFIX,
+            REPORT_TITLE_PERMANENTLY_BANNED_SUFFIX,
+            REPORT_CONTENT_PREFIX,
+            REPORT_CONTENT_PERMANENTLY_BANNED_SUFFIX
+    )
+    ;
+
+
+    private final String ReportFCMTitle;
+    private final String ReportFCMContentPrefix;
+    private final String ReportFCMContentSuffix;
+    private final String ReportTitlePrefix;
+    private final String ReportTitleSuffix;
+    private final String ReportContentPrefix;
+    private final String ReportContentSuffix;
+
+    public String toFCMContent(String nickname) {
+        return switch (this) {
+            case NORMAL, WARNING, PAUSED, BANNED, PERMANENTLY_BANNED ->
+                    this.ReportFCMContentPrefix + nickname + this.ReportFCMContentSuffix;
+        };
+    }
+    public String toTitle(String nickname) {
+        return switch (this) {
+            case NORMAL, WARNING, PAUSED, BANNED, PERMANENTLY_BANNED -> this.ReportTitlePrefix + nickname + this.ReportTitleSuffix;
+        };
+    }
+
+    public String toContent(String nickname, String content, String plubbing) {
+        return switch (this) {
+            case WARNING -> this.ReportContentPrefix + plubbing + "” 에서 ”" + content + this.ReportContentSuffix;
+            case NORMAL, PAUSED, BANNED, PERMANENTLY_BANNED -> this.ReportContentPrefix + nickname + this.ReportContentSuffix;
+        };
+    }
+}

--- a/src/main/java/plub/plubserver/domain/report/controller/ReportController.java
+++ b/src/main/java/plub/plubserver/domain/report/controller/ReportController.java
@@ -4,12 +4,13 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-
 import org.springframework.web.bind.annotation.*;
 import plub.plubserver.common.dto.ApiResponse;
 import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.account.service.AccountService;
-import plub.plubserver.domain.report.dto.ReportDto.*;
+import plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
+import plub.plubserver.domain.report.dto.ReportDto.ReportIdResponse;
+import plub.plubserver.domain.report.dto.ReportDto.ReportTypeResponse;
 import plub.plubserver.domain.report.service.ReportService;
 
 import java.util.List;

--- a/src/main/java/plub/plubserver/domain/report/controller/ReportController.java
+++ b/src/main/java/plub/plubserver/domain/report/controller/ReportController.java
@@ -50,4 +50,14 @@ public class ReportController {
     ) {
         return success(reportService.getReport(reportId));
     }
+
+    @ApiOperation(value = "신고 취소 처리")
+    @PutMapping("/{reportId}/cancel")
+    public ApiResponse<ReportIdResponse> cancelReport(
+            @PathVariable Long reportId,
+            @RequestParam(value = "isCancel") boolean isCancel
+    ) {
+        Account currentAccount = accountService.getCurrentAccount();
+        return success(reportService.cancelReport(reportId, isCancel, currentAccount));
+    }
 }

--- a/src/main/java/plub/plubserver/domain/report/controller/ReportController.java
+++ b/src/main/java/plub/plubserver/domain/report/controller/ReportController.java
@@ -7,6 +7,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.web.bind.annotation.*;
 import plub.plubserver.common.dto.ApiResponse;
+import plub.plubserver.domain.account.model.Account;
+import plub.plubserver.domain.account.service.AccountService;
 import plub.plubserver.domain.report.dto.ReportDto.*;
 import plub.plubserver.domain.report.service.ReportService;
 
@@ -21,11 +23,21 @@ import static plub.plubserver.common.dto.ApiResponse.success;
 @Api(tags = "신고 API", hidden = true)
 public class ReportController {
     private final ReportService reportService;
+    private final AccountService accountService;
 
     @ApiOperation(value = "신고 사유 조회")
     @GetMapping()
     public ApiResponse<List<ReportTypeResponse>> getReportType(
     ) {
         return success(reportService.getReportType());
+    }
+
+    @ApiOperation(value = "신고 생성")
+    @PostMapping()
+    public ApiResponse<ReportIdResponse> createReport(
+            @RequestBody CreateReportRequest reportRequest
+    ) {
+        Account currentAccount = accountService.getCurrentAccount();
+        return success(reportService.createReport(reportRequest, currentAccount));
     }
 }

--- a/src/main/java/plub/plubserver/domain/report/controller/ReportController.java
+++ b/src/main/java/plub/plubserver/domain/report/controller/ReportController.java
@@ -16,6 +16,7 @@ import plub.plubserver.domain.report.service.ReportService;
 import java.util.List;
 
 import static plub.plubserver.common.dto.ApiResponse.success;
+import static plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
 
 @Slf4j
 @RestController
@@ -40,5 +41,13 @@ public class ReportController {
     ) {
         Account currentAccount = accountService.getCurrentAccount();
         return success(reportService.createReport(reportRequest, currentAccount));
+    }
+
+    @ApiOperation(value = "신고 화면 조회")
+    @GetMapping("/{reportId}")
+    public ApiResponse<ReportResponse> getReport(
+            @PathVariable Long reportId
+    ) {
+        return success(reportService.getReport(reportId));
     }
 }

--- a/src/main/java/plub/plubserver/domain/report/dto/ReportDto.java
+++ b/src/main/java/plub/plubserver/domain/report/dto/ReportDto.java
@@ -18,13 +18,15 @@ public class ReportDto {
         public CreateReportRequest {
         }
 
-        public Report toEntity(Account reporter) {
+        public Report toEntity(Account reporter, Account reportedAccount) {
             return Report.builder()
                     .reportType(ReportType.toEnum(reportType))
                     .reportTarget(ReportTarget.toEnum(reportTarget))
                     .targetId(reportTargetId)
                     .content(content)
-                    .account(reporter)
+                    .reporter(reporter)
+                    .reportedAccount(reportedAccount)
+                    .isCanceled(false)
                     .build();
         }
     }
@@ -59,6 +61,20 @@ public class ReportDto {
     ) {
         @Builder
         public ReportTypeResponse {
+        }
+    }
+
+    public record ReportIdResponse(
+            Long reportId
+    ) {
+        @Builder
+        public ReportIdResponse {
+        }
+
+        public static ReportIdResponse of(Report report) {
+            return ReportIdResponse.builder()
+                    .reportId(report.getId())
+                    .build();
         }
     }
 }

--- a/src/main/java/plub/plubserver/domain/report/dto/ReportDto.java
+++ b/src/main/java/plub/plubserver/domain/report/dto/ReportDto.java
@@ -26,7 +26,7 @@ public class ReportDto {
                     .content(content)
                     .reporter(reporter)
                     .reportedAccount(reportedAccount)
-                    .isCanceled(false)
+                    .checkCanceled(false)
                     .build();
         }
     }

--- a/src/main/java/plub/plubserver/domain/report/dto/ReportDto.java
+++ b/src/main/java/plub/plubserver/domain/report/dto/ReportDto.java
@@ -12,18 +12,20 @@ public class ReportDto {
             String reportType,
             String reportTarget,
             Long reportTargetId,
-            String content
+            Long plubbingId,
+            String reportReason
     ) {
         @Builder
         public CreateReportRequest {
         }
 
-        public Report toEntity(Account reporter, Account reportedAccount) {
+        public Report toEntity(Account reporter, Account reportedAccount, Long plubbingId) {
             return Report.builder()
                     .reportType(ReportType.toEnum(reportType))
                     .reportTarget(ReportTarget.toEnum(reportTarget))
                     .targetId(reportTargetId)
-                    .content(content)
+                    .reportReason(reportReason)
+                    .plubbingId(plubbingId)
                     .reporter(reporter)
                     .reportedAccount(reportedAccount)
                     .checkCanceled(false)
@@ -36,21 +38,23 @@ public class ReportDto {
             Long targetId,
             String reportType,
             String reportTarget,
-            String content,
-            String message
+            String reportTitle,
+            String reportContent,
+            String reportedAt
     ) {
         @Builder
         public ReportResponse {
         }
 
-        public static ReportResponse of(Report report, String message) {
+        public static ReportResponse of(Report report, String title, String content) {
             return ReportResponse.builder()
                     .reportId(report.getId())
                     .targetId(report.getTargetId())
                     .reportType(report.getReportType().toString())
                     .reportTarget(report.getReportTarget().toString())
-                    .content(report.getContent())
-                    .message(message)
+                    .reportTitle(title)
+                    .reportContent(content)
+                    .reportedAt(report.getCreatedAt())
                     .build();
         }
     }

--- a/src/main/java/plub/plubserver/domain/report/model/Report.java
+++ b/src/main/java/plub/plubserver/domain/report/model/Report.java
@@ -49,4 +49,9 @@ public class Report extends BaseEntity {
     public void setReportStatusMessage(ReportStatusMessage reportStatusMessage) {
         this.reportStatusMessage = reportStatusMessage;
     }
+
+    public void cancelReport(boolean checkCanceled) {
+        this.checkCanceled = checkCanceled;
+        this.canceledDate = LocalDateTime.now();
+    }
 }

--- a/src/main/java/plub/plubserver/domain/report/model/Report.java
+++ b/src/main/java/plub/plubserver/domain/report/model/Report.java
@@ -29,7 +29,7 @@ public class Report extends BaseEntity {
 
     private Long targetId;
 
-    private boolean isCanceled;
+    private boolean checkCanceled;
 
     private LocalDateTime canceledDate;
 

--- a/src/main/java/plub/plubserver/domain/report/model/Report.java
+++ b/src/main/java/plub/plubserver/domain/report/model/Report.java
@@ -3,6 +3,7 @@ package plub.plubserver.domain.report.model;
 import lombok.*;
 import plub.plubserver.common.model.BaseEntity;
 import plub.plubserver.domain.account.model.Account;
+import plub.plubserver.domain.report.config.ReportStatusMessage;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
@@ -22,7 +23,7 @@ public class Report extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private ReportType reportType;
 
-    private String content;
+    private String reportReason;
 
     @Enumerated(EnumType.STRING)
     private ReportTarget reportTarget;
@@ -41,5 +42,11 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "reported_account_id")
     private Account reportedAccount;
 
+    private Long plubbingId;
 
+    private ReportStatusMessage reportStatusMessage;
+
+    public void setReportStatusMessage(ReportStatusMessage reportStatusMessage) {
+        this.reportStatusMessage = reportStatusMessage;
+    }
 }

--- a/src/main/java/plub/plubserver/domain/report/model/Report.java
+++ b/src/main/java/plub/plubserver/domain/report/model/Report.java
@@ -5,6 +5,7 @@ import plub.plubserver.common.model.BaseEntity;
 import plub.plubserver.domain.account.model.Account;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -28,8 +29,17 @@ public class Report extends BaseEntity {
 
     private Long targetId;
 
+    private boolean isCanceled;
+
+    private LocalDateTime canceledDate;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "account_id")
-    private Account account;
+    @JoinColumn(name = "reporter_account_id")
+    private Account reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_account_id")
+    private Account reportedAccount;
+
 
 }

--- a/src/main/java/plub/plubserver/domain/report/model/ReportTarget.java
+++ b/src/main/java/plub/plubserver/domain/report/model/ReportTarget.java
@@ -1,13 +1,14 @@
 package plub.plubserver.domain.report.model;
 
 public enum ReportTarget {
-    ACCOUNT, // 계정
+    ACCOUNT, // 계정(프로필)
     PLUBBING, // 플럽밍
     RECRUIT, // 모집
     TODO, // 할일
     ARCHIVE, // 아카이브
     FEED, // 피드
-    COMMENT; // 댓글
+    FEED_COMMENT, // 피드 댓글
+    NOTICE_COMMENT; // 공지 댓글
 
     public static ReportTarget toEnum(String stringParam) {
         return switch (stringParam.toUpperCase()) {
@@ -17,7 +18,8 @@ public enum ReportTarget {
             case "TODO" -> TODO;
             case "ARCHIVE" -> ARCHIVE;
             case "FEED" -> FEED;
-            case "COMMENT" -> COMMENT;
+            case "FEED_COMMENT" -> FEED_COMMENT;
+            case "NOTICE_COMMENT" -> NOTICE_COMMENT;
             default -> throw new IllegalArgumentException("ReportTarget is not valid.");
         };
     }

--- a/src/main/java/plub/plubserver/domain/report/model/ReportTarget.java
+++ b/src/main/java/plub/plubserver/domain/report/model/ReportTarget.java
@@ -2,7 +2,6 @@ package plub.plubserver.domain.report.model;
 
 public enum ReportTarget {
     ACCOUNT, // 계정(프로필)
-    PLUBBING, // 플럽밍
     RECRUIT, // 모집
     TODO, // 할일
     ARCHIVE, // 아카이브
@@ -13,7 +12,6 @@ public enum ReportTarget {
     public static ReportTarget toEnum(String stringParam) {
         return switch (stringParam.toUpperCase()) {
             case "ACCOUNT" -> ACCOUNT;
-            case "PLUBBING" -> PLUBBING;
             case "RECRUIT" -> RECRUIT;
             case "TODO" -> TODO;
             case "ARCHIVE" -> ARCHIVE;

--- a/src/main/java/plub/plubserver/domain/report/repositoy/ReportRepository.java
+++ b/src/main/java/plub/plubserver/domain/report/repositoy/ReportRepository.java
@@ -5,6 +5,8 @@ import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.report.model.Report;
 import plub.plubserver.domain.report.model.ReportTarget;
 
+import java.util.List;
+
 public interface ReportRepository extends JpaRepository<Report, Long> {
     Long countByReportedAccountAndCheckCanceledFalse(Account account);
 
@@ -13,4 +15,8 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
             Account reportedAccount,
             ReportTarget reportTarget
     );
+
+    Long countByReporterAndCreatedAtBetween(Account reporter, String start, String end);
+
+    List<Report> findAllByReporter(Account reporter);
 }

--- a/src/main/java/plub/plubserver/domain/report/repositoy/ReportRepository.java
+++ b/src/main/java/plub/plubserver/domain/report/repositoy/ReportRepository.java
@@ -1,13 +1,9 @@
 package plub.plubserver.domain.report.repositoy;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.report.model.Report;
-import plub.plubserver.domain.report.model.ReportTarget;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-
-    @Query("select count(r) from Report r where r.targetId = :targetId and r.reportTarget = :target")
-    Long countByReportTargetIdAndReportTarget(@Param("targetId") Long targetId, @Param("target") ReportTarget target);
+    Long countByReportedAccount(Account account);
 }

--- a/src/main/java/plub/plubserver/domain/report/repositoy/ReportRepository.java
+++ b/src/main/java/plub/plubserver/domain/report/repositoy/ReportRepository.java
@@ -3,7 +3,14 @@ package plub.plubserver.domain.report.repositoy;
 import org.springframework.data.jpa.repository.JpaRepository;
 import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.report.model.Report;
+import plub.plubserver.domain.report.model.ReportTarget;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-    Long countByReportedAccount(Account account);
+    Long countByReportedAccountAndCheckCanceledFalse(Account account);
+
+    boolean existsByReporterAndReportedAccountAndReportTargetAndCheckCanceledFalse(
+            Account reporter,
+            Account reportedAccount,
+            ReportTarget reportTarget
+    );
 }

--- a/src/main/java/plub/plubserver/domain/report/service/ReportService.java
+++ b/src/main/java/plub/plubserver/domain/report/service/ReportService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import plub.plubserver.common.exception.PlubException;
 import plub.plubserver.common.exception.StatusCode;
 import plub.plubserver.domain.account.exception.AccountException;
 import plub.plubserver.domain.account.model.Account;
@@ -17,13 +18,14 @@ import plub.plubserver.domain.feed.repository.FeedCommentRepository;
 import plub.plubserver.domain.feed.repository.FeedRepository;
 import plub.plubserver.domain.notice.exception.NoticeException;
 import plub.plubserver.domain.notice.repository.NoticeCommentRepository;
-import plub.plubserver.domain.notification.dto.NotificationDto;
 import plub.plubserver.domain.notification.dto.NotificationDto.NotifyParams;
 import plub.plubserver.domain.notification.model.NotificationType;
 import plub.plubserver.domain.notification.service.NotificationService;
+import plub.plubserver.domain.plubbing.model.Plubbing;
+import plub.plubserver.domain.plubbing.repository.PlubbingRepository;
 import plub.plubserver.domain.recruit.exception.RecruitException;
 import plub.plubserver.domain.recruit.repository.RecruitRepository;
-import plub.plubserver.domain.report.config.ReportMessage;
+import plub.plubserver.domain.report.config.ReportStatusMessage;
 import plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
 import plub.plubserver.domain.report.dto.ReportDto.ReportTypeResponse;
 import plub.plubserver.domain.report.exception.ReportException;
@@ -35,12 +37,12 @@ import plub.plubserver.domain.todo.exception.TodoException;
 import plub.plubserver.domain.todo.repository.TodoRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static plub.plubserver.domain.account.model.AccountStatus.PAUSED;
 import static plub.plubserver.domain.account.model.AccountStatus.PERMANENTLY_BANNED;
 import static plub.plubserver.domain.notification.model.NotificationType.*;
 import static plub.plubserver.domain.report.config.ReportConstant.*;
-import static plub.plubserver.domain.report.config.ReportMessage.*;
 import static plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
 import static plub.plubserver.domain.report.dto.ReportDto.ReportIdResponse;
 
@@ -61,16 +63,38 @@ public class ReportService {
     private final ArchiveRepository archiveRepository;
     private final RecruitRepository recruitRepository;
 
+    private final PlubbingRepository plubbingRepository;
+
 
     // 신고하기
     @Transactional
     public ReportIdResponse createReport(CreateReportRequest request, Account reporter) {
         Account reportedAccount = checkReportTargetAccount(request.reportTargetId(), request.reportTarget());
-        Report createReport = request.toEntity(reporter, reportedAccount);
+        plubbingRepository.findById(request.plubbingId()).orElseThrow(() -> new PlubException(StatusCode.NOT_FOUND_PLUBBING));
+
+        Report createReport = request.toEntity(reporter, reportedAccount, request.plubbingId());
         checkDuplicateReport(createReport);
+        ReportStatusMessage reportStatusMessage = checkReportFrequency(createReport.getReportedAccount());
+        createReport.setReportStatusMessage(reportStatusMessage);
         Report report = reportRepository.save(createReport);
+        notifyReportedAccount(report);
+
         return ReportIdResponse.of(report);
     }
+
+    // 신고 조회
+    public ReportResponse getReport(Long reportId) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new ReportException(StatusCode.NOT_FOUND_REPORT));
+        ReportStatusMessage reportStatusMessage = report.getReportStatusMessage();
+        String nickname = report.getReportedAccount().getNickname();
+        String reason = report.getReportReason();
+        String plubbingName = checkPlubbingName(report.getPlubbingId());
+        String title = reportStatusMessage.toTitle(nickname);
+        String content = reportStatusMessage.toContent(nickname, reason, plubbingName);
+        return ReportResponse.of(report, title, content);
+    }
+
 
     // 한 유저가 같은 대상을 중복 신고하는 것을 방지
     private void checkDuplicateReport(Report createReport) {
@@ -82,7 +106,7 @@ public class ReportService {
 
     public Account checkReportTargetAccount(Long targetId, String reportTarget) {
         ReportTarget target = ReportTarget.toEnum(reportTarget);
-        Account account = switch (target) {
+        return switch (target) {
             case ACCOUNT ->
                     accountRepository.findById(targetId).orElseThrow(() -> new AccountException(StatusCode.NOT_FOUND_ACCOUNT));
             case FEED ->
@@ -97,9 +121,7 @@ public class ReportService {
                     archiveRepository.findById(targetId).orElseThrow(() -> new ArchiveException(StatusCode.NOT_FOUND_ARCHIVE)).getAccount();
             case RECRUIT ->
                     recruitRepository.findById(targetId).orElseThrow(() -> new RecruitException(StatusCode.NOT_FOUND_RECRUIT)).getPlubbing().getHost();
-            default -> throw new ReportException(StatusCode.REPORT_TARGET_NOT_FOUND);
         };
-        return account;
     }
 
 
@@ -107,12 +129,29 @@ public class ReportService {
         return reportRepository.countByReportedAccountAndCheckCanceledFalse(reportedAccount);
     }
 
-    public ReportResponse notifyReportedAccount(Report report) {
+    private String checkPlubbingName(Long plubbingId) {
+        Optional<Plubbing> plubbing = plubbingRepository.findById(plubbingId);
+        String plubbingName;
+        if (plubbing.isEmpty()) {
+            plubbingName = "알 수 없음";
+        } else {
+            plubbingName = plubbing.get().getName();
+        }
+        return plubbingName;
+    }
+
+    public void notifyReportedAccount(Report report) {
         Account reportedAccount = report.getReportedAccount();
         Long reportedAccountCount = countReportedAccount(reportedAccount);
+        String nickname = reportedAccount.getNickname();
         if (reportedAccountCount >= REPORT_ACCOUNT_BAN_COUNT) {
             // 계정 영구 정지
-            NotifyParams params = createNotifyParams(report, REPORT_TITLE, REPORT_ACCOUNT_BAN_CONTENT, BAN_PERMANENTLY);
+            NotifyParams params = createNotifyParams(
+                    report,
+                    ReportStatusMessage.PERMANENTLY_BANNED.getReportFCMTitle(),
+                    ReportStatusMessage.PERMANENTLY_BANNED.toFCMContent(nickname),
+                    BAN_PERMANENTLY
+            );
             notificationService.pushMessage(params);
             reportedAccount.updateAccountStatus(PERMANENTLY_BANNED);
 
@@ -123,24 +162,39 @@ public class ReportService {
                     .build();
             suspendAccount.setSuspendedDate();
             suspendAccountRepository.save(suspendAccount);
-
-            return ReportResponse.of(report, ReportMessage.REPORT_ACCOUNT_BANNED);
         } else if (reportedAccountCount >= REPORT_ACCOUNT_PAUSED_COUNT) {
             // 계정 1개월 정지
-            NotifyParams params = createNotifyParams(report, REPORT_TITLE, REPORT_ACCOUNT_PAUSED_CONTENT, BAN_ONE_MONTH);
+            NotifyParams params = createNotifyParams(
+                    report,
+                    ReportStatusMessage.PAUSED.getReportFCMTitle(),
+                    ReportStatusMessage.PAUSED.toFCMContent(nickname),
+                    BAN_ONE_MONTH
+            );
             notificationService.pushMessage(params);
 
             // 계정 상태 일시정지로 변경
             reportedAccount.updateAccountStatus(PAUSED);
-
-            return ReportResponse.of(report, ReportMessage.REPORT_ACCOUNT_PAUSED);
         } else if (reportedAccountCount >= REPORT_ACCOUNT_WARNING_PUSH_COUNT) {
             // 경고 알림
-            NotifyParams params = createNotifyParams(report, REPORT_TITLE, REPORT_ACCOUNT_WARING_CONTENT, REPORTED_ONCE);
+            NotifyParams params = createNotifyParams(
+                    report,
+                    ReportStatusMessage.WARNING.getReportFCMTitle(),
+                    ReportStatusMessage.WARNING.toFCMContent(nickname),
+                    REPORTED_ONCE
+            );
             notificationService.pushMessage(params);
-            return ReportResponse.of(report, ReportMessage.REPORT_ACCOUNT_WARNING);
         }
-        return ReportResponse.of(report, ReportMessage.REPORT_SUCCESS);
+    }
+
+    public ReportStatusMessage checkReportFrequency(Account reportedAccount) {
+        Long frequency = countReportedAccount(reportedAccount);
+        if (frequency >= REPORT_ACCOUNT_BAN_COUNT) {
+            return ReportStatusMessage.PERMANENTLY_BANNED;
+        } else if (frequency >= REPORT_ACCOUNT_PAUSED_COUNT) {
+            return ReportStatusMessage.PAUSED;
+        } else {
+            return ReportStatusMessage.WARNING;
+        }
     }
 
     public NotifyParams createNotifyParams(
@@ -170,16 +224,28 @@ public class ReportService {
             Account loginAccount,
             Account reportedAccount,
             String content,
+            ReportStatusMessage reportStatusMessage,
             NotificationType notificationType
     ) {
         Report report = Report.builder()
+                .reportType(ReportType.ETC)
+                .reportTarget(ReportTarget.ACCOUNT)
+                .targetId(reportedAccount.getId())
+                .reportReason(content)
+                .plubbingId(reportedAccount.getAccountPlubbingList().get(0).getPlubbing().getId())
                 .reporter(loginAccount)
                 .reportedAccount(reportedAccount)
-                .reportType(ReportType.ETC)
-                .content(content)
+                .reportStatusMessage(reportStatusMessage)
+                .checkCanceled(true)
                 .build();
         reportRepository.save(report);
-        NotificationDto.NotifyParams params = createNotifyParams(report, REPORT_TITLE_ADMIN, content, notificationType);
+
+        NotifyParams params = createNotifyParams(
+                report,
+                reportStatusMessage.getReportFCMTitle(),
+                reportStatusMessage.toFCMContent(reportedAccount.getNickname()),
+                notificationType
+        );
         notificationService.pushMessage(params);
     }
 }

--- a/src/main/java/plub/plubserver/domain/report/service/ReportService.java
+++ b/src/main/java/plub/plubserver/domain/report/service/ReportService.java
@@ -63,7 +63,6 @@ public class ReportService {
     private final NoticeCommentRepository noticeCommentRepository;
     private final ArchiveRepository archiveRepository;
     private final RecruitRepository recruitRepository;
-
     private final PlubbingRepository plubbingRepository;
 
 
@@ -177,7 +176,9 @@ public class ReportService {
 
             // 디비에 영구 계정 등록
             SuspendAccount suspendAccount = SuspendAccount.builder()
-                    .account(reportedAccount)
+                    .accountId(reportedAccount.getId())
+                    .accountEmail(reportedAccount.getEmail())
+                    .accountDI(reportedAccount.getEmail().split("@")[0])
                     .isSuspended(true)
                     .build();
             suspendAccount.setSuspendedDate();
@@ -194,6 +195,7 @@ public class ReportService {
 
             // 계정 상태 일시정지로 변경
             reportedAccount.updateAccountStatus(PAUSED);
+            reportedAccount.setPausedDate();
         } else if (reportedAccountCount >= REPORT_ACCOUNT_WARNING_PUSH_COUNT) {
             // 경고 알림
             NotifyParams params = createNotifyParams(
@@ -268,7 +270,6 @@ public class ReportService {
         );
         notificationService.pushMessage(params);
     }
-
 
     // 신고 취소 처리
     @Transactional

--- a/src/main/java/plub/plubserver/domain/report/service/ReportService.java
+++ b/src/main/java/plub/plubserver/domain/report/service/ReportService.java
@@ -1,105 +1,155 @@
 package plub.plubserver.domain.report.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import plub.plubserver.common.exception.StatusCode;
+import plub.plubserver.domain.account.exception.AccountException;
 import plub.plubserver.domain.account.model.Account;
-import plub.plubserver.domain.account.service.AccountService;
+import plub.plubserver.domain.account.model.AccountStatus;
+import plub.plubserver.domain.account.model.SuspendAccount;
+import plub.plubserver.domain.account.repository.AccountRepository;
+import plub.plubserver.domain.account.repository.SuspendAccountRepository;
+import plub.plubserver.domain.archive.exception.ArchiveException;
+import plub.plubserver.domain.archive.repository.ArchiveRepository;
+import plub.plubserver.domain.feed.exception.FeedException;
+import plub.plubserver.domain.feed.repository.FeedCommentRepository;
+import plub.plubserver.domain.feed.repository.FeedRepository;
+import plub.plubserver.domain.notice.exception.NoticeException;
+import plub.plubserver.domain.notice.repository.NoticeCommentRepository;
 import plub.plubserver.domain.notification.dto.NotificationDto.NotifyParams;
 import plub.plubserver.domain.notification.model.NotificationType;
 import plub.plubserver.domain.notification.service.NotificationService;
-import plub.plubserver.domain.plubbing.model.Plubbing;
+import plub.plubserver.domain.recruit.exception.RecruitException;
+import plub.plubserver.domain.recruit.repository.RecruitRepository;
 import plub.plubserver.domain.report.config.ReportMessage;
 import plub.plubserver.domain.report.dto.ReportDto.ReportResponse;
 import plub.plubserver.domain.report.dto.ReportDto.ReportTypeResponse;
+import plub.plubserver.domain.report.exception.ReportException;
 import plub.plubserver.domain.report.model.Report;
 import plub.plubserver.domain.report.model.ReportTarget;
 import plub.plubserver.domain.report.model.ReportType;
 import plub.plubserver.domain.report.repositoy.ReportRepository;
+import plub.plubserver.domain.todo.exception.TodoException;
+import plub.plubserver.domain.todo.repository.TodoRepository;
 
 import java.util.List;
 
+import static plub.plubserver.domain.account.model.AccountStatus.*;
+import static plub.plubserver.domain.notification.model.NotificationType.*;
 import static plub.plubserver.domain.report.config.ReportConstant.*;
+import static plub.plubserver.domain.report.config.ReportMessage.*;
 import static plub.plubserver.domain.report.dto.ReportDto.CreateReportRequest;
+import static plub.plubserver.domain.report.dto.ReportDto.ReportIdResponse;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class ReportService {
     private final ReportRepository reportRepository;
-    private final AccountService accountService;
+    private final AccountRepository accountRepository;
     private final NotificationService notificationService;
+    private final SuspendAccountRepository suspendAccountRepository;
+
+    private final FeedRepository feedRepository;
+    private final TodoRepository todoRepository;
+    private final FeedCommentRepository feedCommentRepository;
+    private final NoticeCommentRepository noticeCommentRepository;
+    private final ArchiveRepository archiveRepository;
+    private final RecruitRepository recruitRepository;
+
 
     // 신고하기
     @Transactional
-    public Report createReport(CreateReportRequest request, Account loginAccount) {
-        Account reporter = accountService.getAccount(loginAccount.getId());
-        Report report = reportRepository.save(request.toEntity(reporter));
-        reporter.addReport(report);
-        return report;
+    public ReportIdResponse createReport(CreateReportRequest request, Account reporter) {
+        Account reportedAccount = checkReportTargetAccount(request.reportTargetId(), request.reportTarget());
+        Report report = reportRepository.save(request.toEntity(reporter, reportedAccount));
+        return ReportIdResponse.of(report);
     }
 
-    public Long getReportCount(Long targetId, ReportTarget target) {
-        return reportRepository.countByReportTargetIdAndReportTarget(targetId, target);
-    }
-
-    // TODO : 신고 바뀐 정책에 따라서 수정 필요
-    public ReportResponse notifyHost(Report report, Plubbing plubbing) {
-        Long reportCount = getReportCount(report.getTargetId(), report.getReportTarget());
-        NotifyParams.NotifyParamsBuilder paramsBuilder = NotifyParams.builder()
-                .receiver(plubbing.getHost())
-                .redirectTargetId(plubbing.getId())
-                .title("신고");
-        if (reportCount >= REPORT_PLUBBING_PAUSE_COUNT) {
-            // 모임 정지
-            NotifyParams params = paramsBuilder.type(NotificationType.BAN_PERMANENTLY)
-                    .content(plubbing.getName() + "모임장 경고 3회 누적으로 모임이 영구정지 되었습니다.")
-                    .build();
-            notificationService.pushMessage(params);
-            return ReportResponse.of(report, ReportMessage.REPORT_PLUBBING_PAUSED);
+    public Account checkReportTargetAccount(Long targetId, String reportTarget) {
+        ReportTarget target = ReportTarget.toEnum(reportTarget);
+        if (target == ReportTarget.ACCOUNT) {
+            return accountRepository.findById(targetId).orElseThrow(() -> new AccountException(StatusCode.NOT_FOUND_ACCOUNT));
+        } else if (target == ReportTarget.FEED) {
+            return feedRepository.findById(targetId).orElseThrow(() -> new FeedException(StatusCode.NOT_FOUND_FEED))
+                    .getAccount();
+        } else if (target == ReportTarget.FEED_COMMENT) {
+            return feedCommentRepository.findById(targetId).orElseThrow(() -> new FeedException(StatusCode.NOT_FOUND_COMMENT))
+                    .getAccount();
+        } else if (target == ReportTarget.NOTICE_COMMENT) {
+            return noticeCommentRepository.findById(targetId).orElseThrow(() -> new NoticeException(StatusCode.NOT_FOUND_COMMENT))
+                    .getAccount();
+        } else if (target == ReportTarget.TODO) {
+            return todoRepository.findById(targetId).orElseThrow(() -> new TodoException(StatusCode.NOT_FOUNT_TODO))
+                    .getAccount();
+        } else if (target == ReportTarget.ARCHIVE) {
+            return archiveRepository.findById(targetId).orElseThrow(() -> new ArchiveException(StatusCode.NOT_FOUND_ARCHIVE))
+                    .getAccount();
+        } else if (target == ReportTarget.RECRUIT) {
+            return recruitRepository.findById(targetId).orElseThrow(() -> new RecruitException(StatusCode.NOT_FOUND_RECRUIT))
+                    .getPlubbing().getHost();
+        } else {
+            throw new ReportException(StatusCode.REPORT_TARGET_NOT_FOUND);
         }
-        if (reportCount >= REPORT_WARNING_PUSH_COUNT) {
-            // 모임장에게 경고 알림
-            NotifyParams params = paramsBuilder.type(NotificationType.BAN_ONE_MONTH)
-                    .content(plubbing.getName() + "에 6회 이상 다른 사용자의 신고가 누적되어 되었습니다.")
-                    .build();
-            notificationService.pushMessage(params);
-            return ReportResponse.of(report, ReportMessage.REPORT_HOST_NOTIFY);
-        }
-        return ReportResponse.of(report, ReportMessage.REPORT_SUCCESS);
     }
 
-    public ReportResponse notifyAccount(Report report, Account account) {
-        Long reportCount = getReportCount(report.getTargetId(), report.getReportTarget());
-        NotifyParams.NotifyParamsBuilder paramsBuilder = NotifyParams.builder()
-                .receiver(account)
-                .redirectTargetId(account.getId())
-                .title("신고");
+    public Long countReportedAccount(Account reportedAccount) {
+        return reportRepository.countByReportedAccount(reportedAccount);
+    }
 
-        if (reportCount >= REPORT_ACCOUNT_WARNING_PUSH_COUNT) {
+    public ReportResponse notifyReportedAccount(Report report) {
+        Account reportedAccount = report.getReportedAccount();
+        Long reportedAccountCount = countReportedAccount(reportedAccount);
+        if (reportedAccountCount >= REPORT_ACCOUNT_BAN_COUNT) {
+            // 계정 영구 정지
+            NotifyParams params = createNotifyParams(report, REPORT_ACCOUNT_BAN_CONTENT, BAN_PERMANENTLY);
+            notificationService.pushMessage(params);
+            reportedAccount.updateAccountStatus(PERMANENTLY_BANNED);
+
+            // 디비에 영구 계정 등록
+            SuspendAccount suspendAccount = SuspendAccount.builder()
+                    .account(reportedAccount)
+                    .isSuspended(true)
+                    .build();
+            suspendAccount.setSuspendedDate();
+            suspendAccountRepository.save(suspendAccount);
+
+            return ReportResponse.of(report, ReportMessage.REPORT_ACCOUNT_BANNED);
+        }
+        else if (reportedAccountCount >= REPORT_ACCOUNT_PAUSED_COUNT) {
+            // 계정 1개월 정지
+            NotifyParams params = createNotifyParams(report, REPORT_ACCOUNT_PAUSED_CONTENT, BAN_ONE_MONTH);
+             notificationService.pushMessage(params);
+
+            // 계정 상태 일시정지로 변경
+            reportedAccount.updateAccountStatus(PAUSED);
+
+            return ReportResponse.of(report, ReportMessage.REPORT_ACCOUNT_PAUSED);
+        }
+        else if (reportedAccountCount >= REPORT_ACCOUNT_WARNING_PUSH_COUNT) {
             // 경고 알림
-            NotifyParams params = paramsBuilder.type(NotificationType.BAN_PERMANENTLY)
-                    .content("경고 1회 입니다. 경고 3회 누적시 계정이 1개월 정지 됩니다.")
-                    .build();
+            NotifyParams params = createNotifyParams(report, REPORT_ACCOUNT_WARING_CONTENT, REPORTED_ONCE);
             notificationService.pushMessage(params);
             return ReportResponse.of(report, ReportMessage.REPORT_ACCOUNT_WARNING);
         }
-        else if (reportCount >= REPORT_ACCOUNT_PAUSED_COUNT) {
-            // 계정 1개월 정지
-            NotifyParams params = paramsBuilder.type(NotificationType.BAN_ONE_MONTH)
-                    .content("경고 3회 누적으로 계정이 1개월 정지 되었습니다.")
-                    .build();
-            notificationService.pushMessage(params);
-            return ReportResponse.of(report, ReportMessage.REPORT_ACCOUNT_PAUSED);
-        }else if (reportCount >= REPORT_ACCOUNT_BAN_COUNT) {
-            // 계정 영구 정지
-            NotifyParams params = paramsBuilder.type(NotificationType.BAN_PERMANENTLY)
-                    .content("경고 6회 누적으로 계정이 영구 정지 되었습니다.")
-                    .build();
-            notificationService.pushMessage(params);
-            return ReportResponse.of(report, ReportMessage.REPORT_ACCOUNT_BANNED);
-        }
         return ReportResponse.of(report, ReportMessage.REPORT_SUCCESS);
+    }
+
+    public NotifyParams createNotifyParams(
+            Report report,
+            String reportMessage,
+            NotificationType notificationType
+    ) {
+        return NotifyParams.builder()
+                .receiver(report.getReportedAccount())
+                .redirectTargetId(report.getId())
+                .title("신고")
+                .content(reportMessage)
+                .type(notificationType)
+                .build();
     }
 
     public List<ReportTypeResponse> getReportType() {
@@ -109,4 +159,41 @@ public class ReportService {
                 new ReportTypeResponse(ReportType.ADVERTISEMENT.toString(), ReportType.ADVERTISEMENT.getDetailContent()),
                 new ReportTypeResponse(ReportType.ETC.toString(), ReportType.ETC.getDetailContent()));
     }
+
+    // 회원 영구 정지 해제
+    @Transactional
+    public void unsuspendAccount(Account account) {
+        SuspendAccount suspendAccount = suspendAccountRepository.findByAccount(account)
+                        .orElseThrow(() -> new ReportException(StatusCode.NOT_FOUND_SUSPEND_ACCOUNT));
+        suspendAccount.setSuspended(false);
+        suspendAccount.getAccount().updateAccountStatus(NORMAL);
+    }
+
+    // 회원 상태 변경
+    @Transactional
+    public void changeAccountStatus(Account loginAccount, Account reportedAccount, String status) {
+        loginAccount.isAdmin();
+        if (reportedAccount.getAccountStatus() == AccountStatus.PERMANENTLY_BANNED) {
+            throw new ReportException(StatusCode.CANNOT_CHANGE_PERMANENTLY_BANNED_ACCOUNT);
+        }
+        else if(status.equals("PERMANENTLY_BANNED")) {
+            SuspendAccount suspendAccount = SuspendAccount.builder()
+                    .account(reportedAccount)
+                    .isSuspended(true)
+                    .build();
+            suspendAccount.setSuspendedDate();
+            suspendAccountRepository.save(suspendAccount);
+
+            Report report = Report.builder()
+                    .reporter(loginAccount)
+                    .reportedAccount(reportedAccount)
+                    .reportType(ReportType.ETC)
+                    .content(ADMIN_REPORT_ACCOUNT_BAN)
+                    .build();
+            NotifyParams params = createNotifyParams(report, REPORT_ACCOUNT_BAN_CONTENT, BAN_PERMANENTLY);
+            notificationService.pushMessage(params);
+        }
+        reportedAccount.updateAccountStatus(AccountStatus.valueOf(status));
+    }
+
 }

--- a/src/main/java/plub/plubserver/domain/test/TestController.java
+++ b/src/main/java/plub/plubserver/domain/test/TestController.java
@@ -59,6 +59,6 @@ public class TestController {
                 .content("자기 자신의 아이디를 리턴")
                 .build();
         notificationService.pushMessageForceSave(params);
-        return success(notificationService.getMyNotifications());
+        return success(notificationService.getMyNotifications(currentAccount));
     }
 }


### PR DESCRIPTION
## 관련 이슈
- x

## 구현한 내용 또는 수정한 내용
- 회원 영구 정지 SuspendAccount 추가 및 아일랜드 테이블 설정
- 기획 변경에 따른 정지 기능 통합
- 신고 횟수에 따라 화면 내용 변경 (ReportStatusMessage 이용해서 Message 처리)
- 어드민에서 신고 처리 및 Account 상태 변경
- 신고 주 2회 제한
- 정지 시 로그인 제한

## 추가적으로 알리고 싶은 내용
- 회원 기능 통합했습니다.
- 신고 시 유저 상태에 따라서 메시지 내용이 달라져서 ReportStatusMessage Enum 타입으로 처리하고 있습니다..!
- 추후 번호 추가 시 암호화랑 회원 정지 기능 때 추가로 정보를 넣어야 될 것 같습니다
- 지금 테이블 컬럼들이 많이 변경되어서 배포할 때 확인 해 주셔야 됩니다!

## TODO / 고민하고 있는 것들  
- 신고 기능 통합에 따른 ReportService 에 의존성 증가

<br/>

## 배포 Checklist
 <!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->
- [x] SecretKey 를 업데이트 해주세요.
- [x] 본인을 Assign 해주세요.
- [x] 본인을 제외한 백엔드 개발자를 리뷰어로 지정해주세요.
- [x] JIRA 이슈 번호 등록 및 업데이트 해주세요.
- [x] 라벨 체크해주세요. 

<br/>
