### PR TITLE
[PLUB-173] 회원 탈퇴 개선 및 신고 정책 변경

### DIFF
--- a/src/main/java/plub/plubserver/common/constant/GlobalConstants.java
+++ b/src/main/java/plub/plubserver/common/constant/GlobalConstants.java
@@ -10,9 +10,23 @@ public class GlobalConstants {
     /**
      * Report
      */
-    public static final int REPORT_WARNING_PUSH_COUNT = 6;
-    public static final int REPORT_PLUBBING_PAUSE_COUNT = 18;
     public static final int REPORT_ACCOUNT_WARNING_PUSH_COUNT = 1;
     public static final int REPORT_ACCOUNT_PAUSED_COUNT = 3;
     public static final int REPORT_ACCOUNT_BAN_COUNT = 6;
+
+    public static final int RECRUIT_CHECK_FREQUENCY = 20;
+    public static final int RECRUIT_CHECK_RECENT_FREQUENCY = 10;
+    public static final int FEED_CHECK_FREQUENCY = 10;
+    public static final int FEED_CHECK_RECENT_FREQUENCY = 4;
+    public static final int TODO_CHECK_FREQUENCY = 10;
+    public static final int TODO_CHECK_RECENT_FREQUENCY = 4;
+    public static final int ARCHIVE_CHECK_FREQUENCY = 10;
+    public static final int ARCHIVE_CHECK_RECENT_FREQUENCY = 4;
+    public static final int FEED_COMMENT_CHECK_FREQUENCY = 10;
+    public static final int FEED_COMMENT_CHECK_RECENT_FREQUENCY = 5;
+    public static final int NOTICE_COMMENT_CHECK_FREQUENCY = 10;
+    public static final int NOTICE_COMMENT_CHECK_RECENT_FREQUENCY = 5;
+    public static final int ACCOUNT_CHECK_FREQUENCY = 10;
+    public static final int ACCOUNT_CHECK_RECENT_FREQUENCY = 5;
+
 }

--- a/src/main/java/plub/plubserver/common/exception/StatusCode.java
+++ b/src/main/java/plub/plubserver/common/exception/StatusCode.java
@@ -19,7 +19,8 @@ public enum StatusCode {
     PAUSED_ACCOUNT(400, 9070, "paused account error."),
     BANNED_ACCOUNT(400, 9080, "banned account error."),
     PERMANENTLY_BANNED_ACCOUNT(400, 9090, "permanently banned account error."),
-
+    INACTIVE_ACCOUNT(400, 9100, "inactive account error."),
+    DORMANT_ACCOUNT(400, 9110, "dormant account error."),
 
     /**
      * Account
@@ -33,6 +34,7 @@ public enum StatusCode {
     SELF_REPORT_ERROR(400, 2060, "self report error."),
     SUSPENDED_ACCOUNT(400, 2070, "suspended account error."),
     NICKNAME_CHANGE_LIMIT(400, 2080, "nickname change limit error."),
+    ALREADY_INACTIVE_ACCOUNT(400, 2090, "already inactive account error."),
 
     /**
      * Auth

--- a/src/main/java/plub/plubserver/config/jwt/RefreshTokenRepository.java
+++ b/src/main/java/plub/plubserver/config/jwt/RefreshTokenRepository.java
@@ -10,4 +10,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     Optional<RefreshToken> findByAccount(Account account);
 
     void deleteByAccount(Account account);
+
+    boolean existsByAccount(Account account);
 }

--- a/src/main/java/plub/plubserver/config/jwt/RefreshTokenRepository.java
+++ b/src/main/java/plub/plubserver/config/jwt/RefreshTokenRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
     Optional<RefreshToken> findByAccount(Account account);
+
+    void deleteByAccount(Account account);
 }

--- a/src/main/java/plub/plubserver/domain/account/controller/AccountController.java
+++ b/src/main/java/plub/plubserver/domain/account/controller/AccountController.java
@@ -116,6 +116,15 @@ public class AccountController {
         Account currentAccount = accountService.getCurrentAccount();
         return success(accountService.unSuspendAccount(currentAccount, accountId));
     }
+
+    @ApiOperation(value = "회원 비활성화 설정/해제")
+    @PutMapping("/inActive")
+    public ApiResponse<AccountIdResponse> inActiveAccount(
+            @RequestParam(value = "push-notification", defaultValue = "true") boolean isInactive
+    ) {
+        Account currentAccount = accountService.getCurrentAccount();
+        return success(accountService.inActiveAccount(currentAccount, isInactive));
+    }
 }
 
 

--- a/src/main/java/plub/plubserver/domain/account/controller/AuthController.java
+++ b/src/main/java/plub/plubserver/domain/account/controller/AuthController.java
@@ -6,11 +6,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import plub.plubserver.common.dto.ApiResponse;
 import plub.plubserver.config.jwt.JwtDto;
+import plub.plubserver.domain.account.dto.AccountDto;
 import plub.plubserver.domain.account.service.AuthService;
 
 import javax.validation.Valid;
 
 import static plub.plubserver.common.dto.ApiResponse.success;
+import static plub.plubserver.domain.account.dto.AccountDto.*;
 import static plub.plubserver.domain.account.dto.AuthDto.*;
 
 @RestController
@@ -43,7 +45,7 @@ public class AuthController {
 
     @ApiOperation(value = "로그아웃")
     @GetMapping("/logout")
-    public ApiResponse<String> logout() {
+    public ApiResponse<LogoutResponse> logout() {
         return success(authService.logout());
     }
 

--- a/src/main/java/plub/plubserver/domain/account/dto/AccountDto.java
+++ b/src/main/java/plub/plubserver/domain/account/dto/AccountDto.java
@@ -176,5 +176,13 @@ public class AccountDto {
             return new AccountIdResponse(account.getId());
         }
     }
+
+    public record LogoutResponse(
+            boolean isLogout
+    ) {
+        public static LogoutResponse of(boolean isLogout) {
+            return new LogoutResponse(!isLogout);
+        }
+    }
 }
 

--- a/src/main/java/plub/plubserver/domain/account/model/Account.java
+++ b/src/main/java/plub/plubserver/domain/account/model/Account.java
@@ -252,4 +252,18 @@ public class Account extends BaseEntity {
         this.pausedStartDate = LocalDateTime.now();
         this.pausedEndDate = LocalDateTime.now().plusMonths(1);
     }
+
+    public void deletedAccount() {
+        this.accountStatus = AccountStatus.DELETED;
+        this.email = null;
+        this.password = null;
+        this.nickname = null;
+        this.profileImage = null;
+        this.introduce = null;
+        this.birthday = null;
+        this.gender = null;
+        this.age = 0;
+        this.phone = null;
+        this.socialType = null;
+    }
 }

--- a/src/main/java/plub/plubserver/domain/account/model/Account.java
+++ b/src/main/java/plub/plubserver/domain/account/model/Account.java
@@ -70,6 +70,8 @@ public class Account extends BaseEntity {
 
     private LocalDateTime lastInActiveDate;
 
+    private int reportCount;
+
     // 회원(1) - 차단 사용자(다)
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BanAccount> bannedAccounts = new ArrayList<>();
@@ -271,5 +273,13 @@ public class Account extends BaseEntity {
 
     public void updateLastInActiveDate() {
         this.lastInActiveDate = LocalDateTime.now();
+    }
+
+    public void plusReportCount() {
+        this.reportCount++;
+    }
+
+    public void minusReportCount() {
+        if (this.reportCount > 0) this.reportCount--;
     }
 }

--- a/src/main/java/plub/plubserver/domain/account/model/Account.java
+++ b/src/main/java/plub/plubserver/domain/account/model/Account.java
@@ -68,6 +68,8 @@ public class Account extends BaseEntity {
     private LocalDateTime pausedStartDate;
     private LocalDateTime pausedEndDate;
 
+    private LocalDateTime lastInActiveDate;
+
     // 회원(1) - 차단 사용자(다)
     @OneToMany(mappedBy = "account", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BanAccount> bannedAccounts = new ArrayList<>();
@@ -265,5 +267,9 @@ public class Account extends BaseEntity {
         this.age = 0;
         this.phone = null;
         this.socialType = null;
+    }
+
+    public void updateLastInActiveDate() {
+        this.lastInActiveDate = LocalDateTime.now();
     }
 }

--- a/src/main/java/plub/plubserver/domain/account/model/AccountStatus.java
+++ b/src/main/java/plub/plubserver/domain/account/model/AccountStatus.java
@@ -2,5 +2,5 @@ package plub.plubserver.domain.account.model;
 
 public enum AccountStatus {
     // 정상, 일시 정지, 정지, 영구 정지
-    NORMAL, PAUSED, BANNED, PERMANENTLY_BANNED
+    NORMAL, PAUSED, BANNED, PERMANENTLY_BANNED, DELETED
 }

--- a/src/main/java/plub/plubserver/domain/account/model/AccountStatus.java
+++ b/src/main/java/plub/plubserver/domain/account/model/AccountStatus.java
@@ -1,6 +1,6 @@
 package plub.plubserver.domain.account.model;
 
 public enum AccountStatus {
-    // 정상, 일시 정지, 정지, 영구 정지
-    NORMAL, PAUSED, BANNED, PERMANENTLY_BANNED, DELETED
+    // 정상, 일시 정지, 정지, 영구 정지, 삭제됨, 비활성화, 휴면
+    NORMAL, PAUSED, BANNED, PERMANENTLY_BANNED, DELETED, INACTIVE, DORMANT
 }

--- a/src/main/java/plub/plubserver/domain/account/model/RevokeAccount.java
+++ b/src/main/java/plub/plubserver/domain/account/model/RevokeAccount.java
@@ -1,0 +1,27 @@
+package plub.plubserver.domain.account.model;
+
+import lombok.*;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import java.time.LocalDateTime;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Builder
+public class RevokeAccount {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String email;
+    private SocialType socialType;
+    private String phoneNumber;
+    private String nickname;
+
+    private LocalDateTime revokedAt;
+
+}

--- a/src/main/java/plub/plubserver/domain/account/repository/RevokeAccountRepository.java
+++ b/src/main/java/plub/plubserver/domain/account/repository/RevokeAccountRepository.java
@@ -1,0 +1,7 @@
+package plub.plubserver.domain.account.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import plub.plubserver.domain.account.model.RevokeAccount;
+
+public interface RevokeAccountRepository extends JpaRepository<RevokeAccount, Long> {
+}

--- a/src/main/java/plub/plubserver/domain/account/service/AccountService.java
+++ b/src/main/java/plub/plubserver/domain/account/service/AccountService.java
@@ -7,17 +7,27 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import plub.plubserver.common.exception.StatusCode;
+import plub.plubserver.config.jwt.RefreshTokenRepository;
 import plub.plubserver.domain.account.exception.AccountException;
 import plub.plubserver.domain.account.model.*;
 import plub.plubserver.domain.account.repository.AccountNicknameHistoryRepository;
 import plub.plubserver.domain.account.repository.AccountRepository;
+import plub.plubserver.domain.account.repository.RevokeAccountRepository;
 import plub.plubserver.domain.account.repository.SuspendAccountRepository;
+import plub.plubserver.domain.archive.repository.ArchiveRepository;
+import plub.plubserver.domain.calendar.repository.CalendarRepository;
 import plub.plubserver.domain.category.exception.CategoryException;
 import plub.plubserver.domain.category.model.SubCategory;
 import plub.plubserver.domain.category.repository.SubCategoryRepository;
+import plub.plubserver.domain.feed.repository.FeedRepository;
+import plub.plubserver.domain.notice.repository.NoticeRepository;
+import plub.plubserver.domain.plubbing.repository.AccountPlubbingRepository;
+import plub.plubserver.domain.recruit.repository.AppliedAccountRepository;
+import plub.plubserver.domain.recruit.repository.BookmarkRepository;
 import plub.plubserver.domain.report.config.ReportStatusMessage;
 import plub.plubserver.domain.report.exception.ReportException;
 import plub.plubserver.domain.report.service.ReportService;
+import plub.plubserver.domain.todo.repository.TodoTimelineRepository;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -46,6 +56,17 @@ public class AccountService {
     private final ReportService reportService;
     private final SuspendAccountRepository suspendAccountRepository;
     private final AccountNicknameHistoryRepository accountNicknameHistoryRepository;
+    private final RevokeAccountRepository revokeAccountRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    private final FeedRepository feedRepository;
+    private final TodoTimelineRepository todoTimelineRepository;
+    private final AccountPlubbingRepository accountPlubbingRepository;
+    private final AppliedAccountRepository appliedAccountRepository;
+    private final NoticeRepository noticeRepository;
+    private final ArchiveRepository archiveRepository;
+    private final BookmarkRepository bookmarkRepository;
+    private final CalendarRepository calendarRepository;
 
     // 회원 정보 조회
     public AccountInfoResponse getMyAccount() {
@@ -131,20 +152,42 @@ public class AccountService {
     @Transactional
     public AuthMessage revoke() {
         Account myAccount = getCurrentAccount();
-        String socialName = myAccount.getSocialType().getSocialName();
+        SocialType socialType = myAccount.getSocialType();
         String refreshToken = myAccount.getProviderRefreshToken();
         String[] split = myAccount.getEmail().split("@");
-        boolean result;
-        if (socialName.equalsIgnoreCase("Google")) {
-            result = googleService.revokeGoogle(refreshToken);
-        } else if (socialName.equalsIgnoreCase("Kakao")) {
-            result = kakaoService.revokeKakao(split[0]);
-        } else if (socialName.equalsIgnoreCase("Apple")) {
-            result = appleService.revokeApple(refreshToken);
-        } else {
-            throw new AccountException(StatusCode.SOCIAL_TYPE_ERROR);
+
+        boolean result = switch (socialType) {
+            case GOOGLE -> googleService.revokeGoogle(refreshToken);
+            case KAKAO -> kakaoService.revokeKakao(split[0]);
+            case APPLE -> appleService.revokeApple(refreshToken);
+            default -> throw new AccountException(StatusCode.SOCIAL_TYPE_ERROR);
+        };
+
+        if (result) {
+            RevokeAccount revokeAccount = RevokeAccount.builder()
+                    .email(myAccount.getEmail())
+                    .socialType(socialType)
+                    .phoneNumber(myAccount.getPhone())
+                    .nickname(myAccount.getNickname())
+                    .revokedAt(LocalDateTime.now())
+                    .build();
+            revokeAccountRepository.save(revokeAccount);
+
+            // refreshToken, 지원한 사용자, 가입된 모임, 피드, 투두, 공지, 아카이브, 북마크, 일정 삭제
+            refreshTokenRepository.deleteByAccount(myAccount);
+            appliedAccountRepository.deleteAllByAccount(myAccount);
+            accountPlubbingRepository.deleteAllByAccount(myAccount);
+            feedRepository.deleteAllByAccount(myAccount);
+            todoTimelineRepository.deleteAllByAccount(myAccount);
+            noticeRepository.deleteAllByAccount(myAccount);
+            archiveRepository.deleteAllByAccount(myAccount);
+            bookmarkRepository.deleteAllByAccount(myAccount);
+            calendarRepository.deleteAllByAccount(myAccount);
+
+            myAccount.deletedAccount();
         }
-        return new AuthMessage(result, "revoke result.");
+
+        return new AuthMessage(result, "Revoke result: " + result);
     }
 
     @Transactional

--- a/src/main/java/plub/plubserver/domain/account/service/AuthService.java
+++ b/src/main/java/plub/plubserver/domain/account/service/AuthService.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static plub.plubserver.config.security.SecurityUtils.getCurrentAccountEmail;
+import static plub.plubserver.domain.account.dto.AccountDto.LogoutResponse;
 import static plub.plubserver.domain.account.dto.AuthDto.*;
 
 @Slf4j
@@ -216,16 +217,15 @@ public class AuthService {
     }
 
     @Transactional
-    public String logout() {
-        Account account = accountRepository
-                .findByEmail(getCurrentAccountEmail())
+    public LogoutResponse logout() {
+        Account account = accountRepository.findByEmail(getCurrentAccountEmail())
                 .orElseThrow(() -> new AccountException(StatusCode.NOT_FOUND_ACCOUNT));
-        RefreshToken refreshToken = refreshTokenRepository
-                .findByAccount(account)
+        RefreshToken refreshToken = refreshTokenRepository.findByAccount(account)
                 .orElseThrow(() -> new AuthException(StatusCode.NOT_FOUND_REFRESH_TOKEN));
         refreshTokenRepository.delete(refreshToken);
         refreshTokenRepository.flush();
-        return "로그아웃 완료";
+
+        return LogoutResponse.of(refreshTokenRepository.existsByAccount(account));
     }
 
     public AuthMessage loginAdmin(LoginRequest loginRequest) {

--- a/src/main/java/plub/plubserver/domain/account/service/AuthService.java
+++ b/src/main/java/plub/plubserver/domain/account/service/AuthService.java
@@ -177,7 +177,7 @@ public class AuthService {
 
     public static void checkAccountStatus(Account account) {
         AccountStatus accountStatus = account.getAccountStatus();
-        // NORMAL, PAUSED, BANNED, PERMANENTLY_BANNED
+        // NORMAL, PAUSED, BANNED, PERMANENTLY_BANNED, INACTIVE, DORMANT
         switch (accountStatus) {
             case NORMAL:
                 break;
@@ -193,6 +193,10 @@ public class AuthService {
                 } else throw new AccountException(StatusCode.BANNED_ACCOUNT);
             case PERMANENTLY_BANNED:
                 throw new AccountException(StatusCode.PERMANENTLY_BANNED_ACCOUNT);
+            case INACTIVE:
+                account.updateAccountStatus(AccountStatus.NORMAL);
+            case DORMANT:
+                account.updateAccountStatus(AccountStatus.NORMAL);
         }
     }
 

--- a/src/main/java/plub/plubserver/domain/archive/repository/ArchiveRepository.java
+++ b/src/main/java/plub/plubserver/domain/archive/repository/ArchiveRepository.java
@@ -1,6 +1,7 @@
 package plub.plubserver.domain.archive.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.archive.model.Archive;
 
 import java.util.Optional;
@@ -8,4 +9,6 @@ import java.util.Optional;
 public interface ArchiveRepository extends JpaRepository<Archive, Long>, ArchiveRepositoryCustom {
     Optional<Archive> findFirstByPlubbingIdOrderBySequenceDesc(Long plubbingId);
     Long countAllByPlubbingId(Long plubbingId);
+
+    void deleteAllByAccount(Account account);
 }

--- a/src/main/java/plub/plubserver/domain/calendar/repository/CalendarRepository.java
+++ b/src/main/java/plub/plubserver/domain/calendar/repository/CalendarRepository.java
@@ -3,6 +3,7 @@ package plub.plubserver.domain.calendar.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.calendar.model.Calendar;
 
 import java.util.Optional;
@@ -14,4 +15,6 @@ public interface CalendarRepository extends JpaRepository<Calendar, Long>, Calen
     Optional<Calendar> findByIdAndPlubbingIdAndVisibilityIsTrue(Long id, Long plubbingId);
 
     Optional<Calendar> findFirstByPlubbingIdAndVisibilityIsTrueOrderByStartedAtDesc(Long plubbingId);
+
+    void deleteAllByAccount(Account account);
 }

--- a/src/main/java/plub/plubserver/domain/feed/repository/FeedRepository.java
+++ b/src/main/java/plub/plubserver/domain/feed/repository/FeedRepository.java
@@ -3,6 +3,7 @@ package plub.plubserver.domain.feed.repository;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.feed.model.Feed;
 import plub.plubserver.domain.plubbing.model.Plubbing;
 
@@ -21,4 +22,6 @@ public interface FeedRepository extends JpaRepository<Feed, Long>, FeedRepositor
     Long countAllByPlubbingAndVisibility(Plubbing plubbing, boolean visibility);
 
     Optional<Feed> findByIdAndVisibility(Long feedId, boolean visibility);
+
+    void deleteAllByAccount(Account account);
 }

--- a/src/main/java/plub/plubserver/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/plub/plubserver/domain/notice/repository/NoticeRepository.java
@@ -1,6 +1,7 @@
 package plub.plubserver.domain.notice.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import plub.plubserver.domain.account.model.Account;
 import plub.plubserver.domain.notice.model.Notice;
 import plub.plubserver.domain.plubbing.model.Plubbing;
 
@@ -12,5 +13,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long>, NoticeRep
     Long countAllByPlubbingAndVisibility(Plubbing plubbing, boolean visibility);
 
     Optional<Notice> findByIdAndVisibility(Long noticeId, boolean visibility);
+
+    void deleteAllByAccount(Account account);
 }
 

--- a/src/main/java/plub/plubserver/domain/plubbing/repository/AccountPlubbingRepository.java
+++ b/src/main/java/plub/plubserver/domain/plubbing/repository/AccountPlubbingRepository.java
@@ -29,6 +29,8 @@ public interface AccountPlubbingRepository extends JpaRepository<AccountPlubbing
     Optional<AccountPlubbing> findAllByAccountAndPlubbingAndAccountPlubbingStatusAndIsHost(Account account, Plubbing plubbing, AccountPlubbingStatus active, Boolean isHost);
 
     void deleteByPlubbing(Plubbing plubbing);
+
+    void deleteAllByAccount(Account account);
 }
 
 

--- a/src/main/java/plub/plubserver/domain/recruit/repository/AppliedAccountRepository.java
+++ b/src/main/java/plub/plubserver/domain/recruit/repository/AppliedAccountRepository.java
@@ -24,4 +24,6 @@ public interface AppliedAccountRepository extends JpaRepository<AppliedAccount, 
 
     void deleteAllByRecruitId(Long recruitId);
     List<AppliedAccount> findAllByAccountAndStatus(Account account, ApplicantStatus applicantStatus);
+
+    void deleteAllByAccount(Account account);
 }

--- a/src/main/java/plub/plubserver/domain/recruit/repository/BookmarkRepository.java
+++ b/src/main/java/plub/plubserver/domain/recruit/repository/BookmarkRepository.java
@@ -9,4 +9,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long>, Bookm
     Boolean existsByAccountAndRecruit(Account account, Recruit recruit);
 
     void deleteByRecruit(Recruit recruit);
+
+    void deleteAllByAccount(Account account);
 }

--- a/src/main/java/plub/plubserver/domain/report/repositoy/ReportRepository.java
+++ b/src/main/java/plub/plubserver/domain/report/repositoy/ReportRepository.java
@@ -8,7 +8,9 @@ import plub.plubserver.domain.report.model.ReportTarget;
 import java.util.List;
 
 public interface ReportRepository extends JpaRepository<Report, Long> {
-    Long countByReportedAccountAndCheckCanceledFalse(Account account);
+    Long countByTargetIdAndReportTypeAndCheckCanceledFalse(Long targetId, ReportTarget reportTarget);
+
+    List<Report> findAllByTargetIdAndReportTypeAndCheckCanceledFalse(Long targetId, ReportTarget reportTarget);
 
     boolean existsByReporterAndReportedAccountAndReportTargetAndCheckCanceledFalse(
             Account reporter,

--- a/src/main/java/plub/plubserver/domain/todo/repository/TodoTimelineRepository.java
+++ b/src/main/java/plub/plubserver/domain/todo/repository/TodoTimelineRepository.java
@@ -16,4 +16,6 @@ public interface TodoTimelineRepository extends JpaRepository<TodoTimeline, Long
     Optional<TodoTimeline> findFirstByPlubbingOrderByDateDesc(Plubbing plubbing);
     Optional<TodoTimeline> findByIdAndPlubbing(Long timelineId, Plubbing plubbing);
     Optional<TodoTimeline> findByDateAndAccountAndPlubbing(LocalDate date, Account account, Plubbing plubbing);
+
+    void deleteAllByAccount(Account account);
 }


### PR DESCRIPTION
## 관련 이슈
- X

## 구현한 내용 또는 수정한 내용
- 회원 탈퇴 시 정보 파기 되도록 수정
- 회원 비활성화 API 추가
- 로그아웃 response 변경
- 신고 정책 바뀐 내용 적용

## 추가적으로 알리고 싶은 내용
- account에 reportCount가 추가되어서 배포 시 컬럼 추가해야됩니다
- **리스트 조회 시 visiable 속성 붙여야 됩니다!!!**

## TODO / 고민하고 있는 것들  
- 회원 탈퇴 로직 고민
회원 탈퇴 시 특정 테이블 정보만 삭제를 해야되서 
![image](https://user-images.githubusercontent.com/55054505/235840594-2aaa3255-26f1-4498-bb7d-7057ec4d0d00.png)
해당 방식으로 삭제하고 있는데 더 좋은 방법이 있는지 고민입니다 좋은 의견 있으시면 주세요🙏

- 검토해야 될 신고 리스트 구현 문제
검토해야될 신고 리스트 로직을 짜던 경우 modified_at 값을 써서 검증을 해야되는데 현재 LocalDateTime 이 아니라 String 으로 되어 있어서 로직이 복잡합니다.. ㅠ (포맷을 변경해야 되는 작업 + Between 쿼리 사용 못함..)
그래서 해당 내용을 추후 구현할 생각입니다.

로직을 간단하게 하려면
1. 기존 created_at modified_at 을 LocalDateTime 으로 변경
2. 검토해야될 신고의 경우 새로운 테이블 만들기

이 2가지 방법이 있는 것 같습니다. 더 좋은 방법이 있다면 의견 주시기 바랍니다!

**TODO** 
- 회원 탈퇴 시 Host 인 경우 Host 계승 되는거 설정 (만약 없다면 plubbing 삭제 되는 것도..) 
- 어드민에 검토해야될 신고 내역 리스트 API 만들어야 됩니다.
- 휴면 계정 배치 처리
<br/>

## 배포 Checklist
 <!-- 확인이 된 부분에 모두 [x]로 변경하여 확인했다는 사실을 알려주세요. -->
- [x] SecretKey 를 업데이트 해주세요.
- [x] 본인을 Assign 해주세요.
- [x] 본인을 제외한 백엔드 개발자를 리뷰어로 지정해주세요.
- [x] JIRA 이슈 번호 등록 및 업데이트 해주세요.
- [x] 라벨 체크해주세요. 

<br/>
